### PR TITLE
Fix some problems when compiling with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ objs_dir=objs
 objs+=$(patsubst %.cc,$(objs_dir)/%.o,$(cpp_source))
 
 cxx=g++
-cxxflags=-std=c++11 -Wall -O3 -fopenmp -march=native
+cxxflags=-std=c++11 -Wall -O3 -fopenmp -msse4.1
 ldflags=-lm -lz
 
 exec=chromap
@@ -18,8 +18,8 @@ $(exec): $(objs)
 	$(cxx) $(cxxflags) $(objs) -o $(exec) $(ldflags)
 	
 $(objs_dir)/%.o: $(src_dir)/%.cc
-	$(cxx) $(cxxflags) -c $< -o $@ $(ldflags)
+	$(cxx) $(cxxflags) -c $< -o $@
 
 .PHONY: clean
 clean:
-	-rm -r $(exec) $(objs_dir)
+	-rm -rf $(exec) $(objs_dir)

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -1375,7 +1375,7 @@ void Chromap<MappingRecord>::MapPairedEndReads() {
             num_threads_ / num_reference_sequences);
       }
     }
-#pragma omp parallel default(none) shared(reference, index, read_batch1, read_batch2, barcode_batch, read_batch1_for_loading, read_batch2_for_loading, barcode_batch_for_loading, std::cerr, num_loaded_pairs_for_loading, num_loaded_pairs, num_reference_sequences, mappings_on_diff_ref_seqs_for_diff_threads, mappings_on_diff_ref_seqs_for_diff_threads_for_saving, num_mappings_in_mem, max_num_mappings_in_mem, temp_mapping_file_handles_, mm_to_candidates_cache, mm_history1, mm_history2) num_threads(num_threads_) reduction(+:num_candidates_, num_mappings_, num_mapped_reads_, num_uniquely_mapped_reads_, num_barcode_in_whitelist_, num_corrected_barcode_)
+#pragma omp parallel default(none) shared(output_mappings_not_in_whitelist_, barcode_whitelist_file_path_, trim_adapters_, window_size_, custom_rid_order_path_, split_alignment_, error_threshold_, max_num_best_mappings_, num_threads_, num_reads_, low_memory_mode_, reference, index, read_batch1, read_batch2, barcode_batch, read_batch1_for_loading, read_batch2_for_loading, barcode_batch_for_loading, output_tools_, std::cerr, num_loaded_pairs_for_loading, num_loaded_pairs, num_reference_sequences, mappings_on_diff_ref_seqs_for_diff_threads, mappings_on_diff_ref_seqs_for_diff_threads_for_saving, mappings_on_diff_ref_seqs_, mapping_output_file_path_, num_mappings_in_mem, max_num_mappings_in_mem, temp_mapping_file_handles_, mm_to_candidates_cache, mm_history1, mm_history2) num_threads(num_threads_) reduction(+:num_candidates_, num_mappings_, num_mapped_reads_, num_uniquely_mapped_reads_, num_barcode_in_whitelist_, num_corrected_barcode_)
     {
       thread_num_candidates = 0;
       thread_num_mappings = 0;
@@ -2891,7 +2891,7 @@ void Chromap<MappingRecord>::MapSingleEndReads() {
             num_threads_ / num_reference_sequences);
       }
     }
-#pragma omp parallel default(none) shared(reference, index, read_batch, barcode_batch, read_batch_for_loading, barcode_batch_for_loading, std::cerr, num_loaded_reads_for_loading, num_loaded_reads, num_reference_sequences, mappings_on_diff_ref_seqs_for_diff_threads, mappings_on_diff_ref_seqs_for_diff_threads_for_saving, mm_to_candidates_cache, mm_history) num_threads(num_threads_) reduction(+:num_candidates_, num_mappings_, num_mapped_reads_, num_uniquely_mapped_reads_)
+#pragma omp parallel default(none) shared(window_size_, custom_rid_order_path_, error_threshold_, max_num_best_mappings_, num_threads_, num_reads_, mm_history, reference, index, read_batch, barcode_batch, read_batch_for_loading, barcode_batch_for_loading, std::cerr, num_loaded_reads_for_loading, num_loaded_reads, num_reference_sequences, mappings_on_diff_ref_seqs_for_diff_threads, mappings_on_diff_ref_seqs_for_diff_threads_for_saving, mm_to_candidates_cache) num_threads(num_threads_) reduction(+:num_candidates_, num_mappings_, num_mapped_reads_, num_uniquely_mapped_reads_)
     {
       thread_num_candidates = 0;
       thread_num_mappings = 0;

--- a/src/output_tools.h
+++ b/src/output_tools.h
@@ -5,9 +5,11 @@
 
 #include <cstring>
 #include <functional>
+#include <inttypes.h>
 #include <iostream>
 #include <string>
 #include <vector>
+
 
 #include "sequence_batch.h"
 
@@ -1188,7 +1190,7 @@ class OutputTools {
 
   void WriteMatrixOutputHead(uint64_t num_peaks, uint64_t num_barcodes,
                              uint64_t num_lines) {
-    fprintf(matrix_output_file_, "%lu\t%lu\t%lu\n", num_peaks, num_barcodes,
+    fprintf(matrix_output_file_, "%" PRIu64 "\t%" PRIu64 "\t%" PRIu64 "\n", num_peaks, num_barcodes,
             num_lines);
   }
 


### PR DESCRIPTION
1. Fix warnings of format of uint64_t.
2. Add all used shared variables in OpenMP clause. 