### PR TITLE
Only warn the users when whitelist is NA.

### DIFF
--- a/src/output_tools.h
+++ b/src/output_tools.h
@@ -70,6 +70,10 @@ class OutputTools {
     mapping_output_format_ = format;
   }
 
+  inline void SetBarcodeLength(uint32_t cell_barcode_length) {
+    cell_barcode_length_ = cell_barcode_length;
+  }
+
   inline void FinalizeMappingOutput() { fclose(mapping_output_file_); }
 
   inline void AppendMappingOutput(const std::string &line) {


### PR DESCRIPTION
1. warn the users instead of generating an error when barcode whitelist is not given for single-cell data. 
2. previous implementation needs barcode length from the whitelist. So for now when whitelist is not given, use the length of the first barcode loaded as the barcode length to output barcodes in mappings. The assumption is that all the barcodes share the same length and the length is the length of the first barcode. We do not have to change much code with this solution but we definitely want to revisit this later and may provide a better solution.