### PR TITLE
Barcode translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ dir:
 $(exec): $(objs)
 	$(CXX) $(CXXFLAGS) $(objs) -o $(exec) $(LDFLAGS)
 	
-$(objs_dir)/%.o: $(src_dir)/%.cc
+$(objs_dir)/%.o: $(src_dir)/%.cc $(src_dir)/%.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ objs+=$(patsubst %.cc,$(objs_dir)/%.o,$(cpp_source))
 
 exec=chromap
 
+#asan=1
 ifneq ($(asan),)
-	CXXFLAGS+=-fsanitize=address
-	LDFLAGS+=-fsanitize=address -ldl
+	CXXFLAGS+=-fsanitize=address -g
+	LDFLAGS+=-fsanitize=address -ldl -g
 endif
 
 all: dir $(exec) 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ objs+=$(patsubst %.cc,$(objs_dir)/%.o,$(cpp_source))
 
 exec=chromap
 
-#asan=1
 ifneq ($(asan),)
 	CXXFLAGS+=-fsanitize=address -g
 	LDFLAGS+=-fsanitize=address -ldl -g

--- a/README.md
+++ b/README.md
@@ -168,10 +168,14 @@ Note that chrom_end is open-end. This output fragment file can be used as input 
 downstream analysis tools such as [MAESTRO][MAESTRO], [ArchR][ArchR], [signac][signac]
 and etc.
 
-For the output, Chromap provide the function to translate input cell barcode to another barcode space. 
-User can specify the translation file through the option **--barcode-translate**. 
-The translation file is a two-column tsv/csv file with the original barcode on the second column and the translated barcode on the first column. This is useful for the case of 10x multiome data, where scATAC-seq and scRNA-seq data uses different sets of barcodes. 
-This option also supports combinatorial barcoding, such as SHARE-seq. Chromap translates each barcode segment provided in the second column to the ID of the first column and added "-" to concatenate the IDs in the output.
+Besides, Chromap can translate input cell barcodes to another set of barcodes. 
+Users can specify the translation file through the option **--barcode-translate**. 
+The translation file is a two-column tsv/csv file with the translated barcode on the first column
+and the original barcode on the second column. This is useful for 10x Multiome data, where
+scATAC-seq and scRNA-seq data use different sets of barcodes. This option also supports
+combinatorial barcoding, such as SHARE-seq. Chromap can translate each barcode segment provided
+in the second column to the ID in the first column and add "-" to concatenate the IDs in the
+output.
 
 #### <a name="map-hic"></a>Map Hi-C short reads
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Note that chrom_end is open-end. This output fragment file can be used as input 
 downstream analysis tools such as [MAESTRO][MAESTRO], [ArchR][ArchR], [signac][signac]
 and etc.
 
+For the output, Chromap provide the function to translate input cell barcode to another barcode space. 
+User can specify the translation file through the option **--barcode-translate**. 
+The translation file is a two-column tsv/csv file with the original barcode on the second column and the translated barcode on the first column. This is useful for the case of 10x multiome data, where scATAC-seq and scRNA-seq data uses different sets of barcodes. 
+This option also supports combinatorial barcoding, such as SHARE-seq. Chromap translates each barcode segment provided in the second column to the ID of the first column and added "-" to concatenate the IDs in the output.
+
 #### <a name="map-hic"></a>Map Hi-C short reads
 
 ```sh

--- a/src/barcode_translator.h
+++ b/src/barcode_translator.h
@@ -1,3 +1,6 @@
+#ifndef BARCODETRANSLATOR_H_
+#define BARCODETRANSLATOR_H_
+
 #include <cinttypes>
 #include <cstring>
 #include <functional>
@@ -109,3 +112,4 @@ public:
   }
 };
 }
+#endif

--- a/src/barcode_translator.h
+++ b/src/barcode_translator.h
@@ -3,8 +3,8 @@
 
 #include <cinttypes>
 #include <cstring>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -13,95 +13,64 @@
 
 namespace chromap {
 
-KHASH_INIT(k64_str, uint64_t, char *, 1, kh_int64_hash_func, kh_int64_hash_equal);
+KHASH_INIT(k64_str, uint64_t, char *, 1, kh_int64_hash_func,
+           kh_int64_hash_equal);
 
 // The class for handling barcode convertion.
-class BarcodeTranslator
-{
-private:
-  khash_t(k64_str) *barcode_translate_table;
-  int from_bc_length;
-  uint64_t mask;
-
-  std::string Seed2Sequence(uint64_t seed, uint32_t seed_length) const {
-    std::string sequence;
-    sequence.reserve(seed_length);
-    uint64_t mask = 3;
-    for (uint32_t i = 0; i < seed_length; ++i) {
-      sequence.push_back(SequenceBatch::Uint8ToChar(
-          (seed >> ((seed_length - 1 - i) * 2)) & mask));
-    }
-    return sequence;
-  }
-  
-  void ProcessTranslateFileLine(std::string &line) {
-    int i;
-    int len = line.length();
-    std::string to;
-    for (i = 0; i < len; ++i) {
-      if (line[i] == ',' || line[i] == '\t')
-        break;
-    }
-
-    to = line.substr(0, i);
-    //from = line.substr(i + 1, len - i - 1);
-    from_bc_length = len - i - 1;
-    uint64_t from_seed = SequenceBatch::GenerateSeedFromSequence(line.c_str(), len, i + 1, from_bc_length);
-    
-    int khash_return_code;
-    khiter_t barcode_translate_table_iter = kh_put(k64_str, barcode_translate_table, from_seed, &khash_return_code);
-    kh_value(barcode_translate_table, barcode_translate_table_iter) = strdup(to.c_str());
-  }
-
-public:
+class BarcodeTranslator {
+ public:
   BarcodeTranslator() {
-    barcode_translate_table = NULL;
-    from_bc_length = -1;
+    barcode_translate_table_ = NULL;
+    from_bc_length_ = -1;
   }
-  
+
   ~BarcodeTranslator() {
-    if (barcode_translate_table != NULL) {
-      khiter_t k ;
-      for (k = kh_begin(barcode_translate_table) ; k != kh_end(barcode_translate_table); ++k)
-      {
-        if (kh_exist(barcode_translate_table, k))
-          free(kh_value(barcode_translate_table, k)) ;
+    if (barcode_translate_table_ != NULL) {
+      khiter_t k;
+      for (k = kh_begin(barcode_translate_table_);
+           k != kh_end(barcode_translate_table_); ++k) {
+        if (kh_exist(barcode_translate_table_, k))
+          free(kh_value(barcode_translate_table_, k));
       }
-      kh_destroy(k64_str, barcode_translate_table);
+      kh_destroy(k64_str, barcode_translate_table_);
     }
   }
 
   void SetTranslateTable(const std::string &file) {
-    barcode_translate_table = kh_init(k64_str);
+    barcode_translate_table_ = kh_init(k64_str);
     std::ifstream file_stream(file);
     std::string file_line;
     while (getline(file_stream, file_line)) {
-      ProcessTranslateFileLine(file_line); 
+      ProcessTranslateFileLine(file_line);
     }
-    
-    mask = (1ull<<(2*from_bc_length)) - 1;
-    /*for (int i = 0; i < from_bc_length; ++i)
+
+    mask_ = (1ull << (2 * from_bc_length_)) - 1;
+    /*for (int i = 0; i < from_bc_length_; ++i)
     {
-      mask |= (3ull << (2*i));
+      mask_ |= (3ull << (2*i));
     }*/
   }
-  
-  std::string Translate(uint64_t bc, uint32_t bc_length) {
-    if (barcode_translate_table == NULL) {
-      return Seed2Sequence(bc, bc_length);
-    } 
 
-    std::string ret;  
+  std::string Translate(uint64_t bc, uint32_t bc_length) {
+    if (barcode_translate_table_ == NULL) {
+      return Seed2Sequence(bc, bc_length);
+    }
+
+    std::string ret;
     uint64_t i;
-    for (i = 0; i < bc_length / from_bc_length; ++i) {
-      uint64_t seed = (bc << (2 * i * from_bc_length)) >> (2 * (bc_length / from_bc_length - 1) * from_bc_length);
-      seed &= mask;
-      khiter_t barcode_translate_table_iter = kh_get(k64_str, barcode_translate_table, seed);
-      if (barcode_translate_table_iter == kh_end(barcode_translate_table)) {
-        std::cerr << "Barcode does not exist in the translation table.\n" << std::endl;
+    for (i = 0; i < bc_length / from_bc_length_; ++i) {
+      uint64_t seed = (bc << (2 * i * from_bc_length_)) >>
+                      (2 * (bc_length / from_bc_length_ - 1) * from_bc_length_);
+      seed &= mask_;
+      khiter_t barcode_translate_table_iter =
+          kh_get(k64_str, barcode_translate_table_, seed);
+      if (barcode_translate_table_iter == kh_end(barcode_translate_table_)) {
+        std::cerr << "Barcode does not exist in the translation table."
+                  << std::endl;
         exit(-1);
       }
-      std::string bc_to(kh_value(barcode_translate_table, barcode_translate_table_iter));
+      std::string bc_to(
+          kh_value(barcode_translate_table_, barcode_translate_table_iter));
       if (i == 0) {
         ret = bc_to;
       } else {
@@ -110,6 +79,44 @@ public:
     }
     return ret;
   }
+
+ private:
+  khash_t(k64_str) * barcode_translate_table_;
+  int from_bc_length_;
+  uint64_t mask_;
+
+  std::string Seed2Sequence(uint64_t seed, uint32_t seed_length) const {
+    std::string sequence;
+    sequence.reserve(seed_length);
+    uint64_t mask_ = 3;
+    for (uint32_t i = 0; i < seed_length; ++i) {
+      sequence.push_back(SequenceBatch::Uint8ToChar(
+          (seed >> ((seed_length - 1 - i) * 2)) & mask_));
+    }
+    return sequence;
+  }
+
+  void ProcessTranslateFileLine(std::string &line) {
+    int i;
+    int len = line.length();
+    std::string to;
+    for (i = 0; i < len; ++i) {
+      if (line[i] == ',' || line[i] == '\t') break;
+    }
+
+    to = line.substr(0, i);
+    // from = line.substr(i + 1, len - i - 1);
+    from_bc_length_ = len - i - 1;
+    uint64_t from_seed = SequenceBatch::GenerateSeedFromSequence(
+        line.c_str(), len, i + 1, from_bc_length_);
+
+    int khash_return_code;
+    khiter_t barcode_translate_table_iter = kh_put(
+        k64_str, barcode_translate_table_, from_seed, &khash_return_code);
+    kh_value(barcode_translate_table_, barcode_translate_table_iter) =
+        strdup(to.c_str());
+  }
 };
-}
+
+}  // namespace chromap
 #endif

--- a/src/barcode_translator.h
+++ b/src/barcode_translator.h
@@ -1,0 +1,111 @@
+#include <cinttypes>
+#include <cstring>
+#include <functional>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "khash.h"
+
+namespace chromap {
+
+KHASH_INIT(k64_str, uint64_t, char *, 1, kh_int64_hash_func, kh_int64_hash_equal);
+
+// The class for handling barcode convertion.
+class BarcodeTranslator
+{
+private:
+  khash_t(k64_str) *barcode_translate_table;
+  int from_bc_length;
+  uint64_t mask;
+
+  std::string Seed2Sequence(uint64_t seed, uint32_t seed_length) const {
+    std::string sequence;
+    sequence.reserve(seed_length);
+    uint64_t mask = 3;
+    for (uint32_t i = 0; i < seed_length; ++i) {
+      sequence.push_back(SequenceBatch::Uint8ToChar(
+          (seed >> ((seed_length - 1 - i) * 2)) & mask));
+    }
+    return sequence;
+  }
+  
+  void ProcessTranslateFileLine(std::string &line) {
+    int i;
+    int len = line.length();
+    std::string to;
+    for (i = 0; i < len; ++i) {
+      if (line[i] == ',' || line[i] == '\t')
+        break;
+    }
+
+    to = line.substr(0, i);
+    //from = line.substr(i + 1, len - i - 1);
+    from_bc_length = len - i - 1;
+    uint64_t from_seed = SequenceBatch::GenerateSeedFromSequence(line.c_str(), len, i + 1, from_bc_length);
+    
+    int khash_return_code;
+    khiter_t barcode_translate_table_iter = kh_put(k64_str, barcode_translate_table, from_seed, &khash_return_code);
+    kh_value(barcode_translate_table, barcode_translate_table_iter) = strdup(to.c_str());
+  }
+
+public:
+  BarcodeTranslator() {
+    barcode_translate_table = NULL;
+    from_bc_length = -1;
+  }
+  
+  ~BarcodeTranslator() {
+    if (barcode_translate_table != NULL) {
+      khiter_t k ;
+      for (k = kh_begin(barcode_translate_table) ; k != kh_end(barcode_translate_table); ++k)
+      {
+        if (kh_exist(barcode_translate_table, k))
+          free(kh_value(barcode_translate_table, k)) ;
+      }
+      kh_destroy(k64_str, barcode_translate_table);
+    }
+  }
+
+  void SetTranslateTable(const std::string &file) {
+    barcode_translate_table = kh_init(k64_str);
+    std::ifstream file_stream(file);
+    std::string file_line;
+    while (getline(file_stream, file_line)) {
+      ProcessTranslateFileLine(file_line); 
+    }
+    
+    mask = (1ull<<(2*from_bc_length)) - 1;
+    /*for (int i = 0; i < from_bc_length; ++i)
+    {
+      mask |= (3ull << (2*i));
+    }*/
+  }
+  
+  std::string Translate(uint64_t bc, uint32_t bc_length) {
+    if (barcode_translate_table == NULL) {
+      return Seed2Sequence(bc, bc_length);
+    } 
+
+    std::string ret;  
+    uint64_t i;
+    for (i = 0; i < bc_length / from_bc_length; ++i) {
+      uint64_t seed = (bc << (2 * i * from_bc_length)) >> (2 * (bc_length / from_bc_length - 1) * from_bc_length);
+      seed &= mask;
+      khiter_t barcode_translate_table_iter = kh_get(k64_str, barcode_translate_table, seed);
+      if (barcode_translate_table_iter == kh_end(barcode_translate_table)) {
+        std::cerr << "Barcode does not exist in the translation table.\n" << std::endl;
+        exit(-1);
+      }
+      std::string bc_to(kh_value(barcode_translate_table, barcode_translate_table_iter));
+      if (i == 0) {
+        ret = bc_to;
+      } else {
+        ret += "-" + bc_to;
+      }
+    }
+    return ret;
+  }
+};
+}

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -5912,7 +5912,10 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
           "Output mappings in pairs format (defined by 4DN for HiC data)")(
           "pairs-natural-chr-order",
           "natural chromosome order for pairs flipping",
-          cxxopts::value<std::string>(), "FILE");
+          cxxopts::value<std::string>(), "FILE")
+          ("barcode-translate", 
+           "Convert barcode to the specified sequences during output",
+           cxxopts::value<std::string>(), "FILE");
   //("PAF", "Output mappings in PAF format (only for test)");
   options.add_options()("v,version", "Print version")("h,help", "Print help");
   options.add_options("Development options")("A,match-score", "Match score [1]",
@@ -6214,6 +6217,10 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
     if (result.count("pairs-natural-chr-order")) {
       mapping_parameters.pairs_custom_rid_order_path =
           result["pairs-natural-chr-order"].as<std::string>();
+    }
+
+    if (result.count("barcode-translate")) {
+      mapping_parameters.barcode_translate_table_path = result["barcode-translate"].as<std::string>();
     }
 
     if (result.count("skip-barcode-check")) {

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -2998,8 +2998,6 @@ void Chromap<MappingRecord>::MapSingleEndReads() {
   }
 
   index.Destroy();
-  //OutputMappingStatistics(num_reference_sequences, mappings_on_diff_ref_seqs_,
-  //                        mappings_on_diff_ref_seqs_);
 
   if (Tn5_shift_) {
     ApplyTn5ShiftOnSingleEndMapping(num_reference_sequences,

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -119,6 +119,7 @@ struct MappingParameters {
   std::string matrix_output_prefix;
   std::string custom_rid_order_path;
   std::string pairs_custom_rid_order_path;
+  std::string barcode_translate_table_path;
   bool skip_barcode_check = false;
 };
 
@@ -220,6 +221,10 @@ class Chromap {
     }
 
     ParseReadFormat(mapping_parameters.read_format);
+    if (mapping_parameters.barcode_translate_table_path.length() > 0) {
+      std::string tmp = mapping_parameters.barcode_translate_table_path;
+      output_tools_.SetBarcodeTranslateTable(tmp);
+    }
   }
 
   ~Chromap() {

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -366,18 +366,18 @@ class Chromap {
       int &num_best_mappings_reported,
       std::vector<std::vector<MappingRecord> > &mappings_on_diff_ref_seqs);
   void EmplaceBackMappingRecord(
-      uint32_t read_id, uint32_t barcode, uint32_t fragment_start_position,
+      uint32_t read_id, uint64_t barcode, uint32_t fragment_start_position,
       uint16_t fragment_length, uint8_t mapq, uint8_t direction,
       uint8_t is_unique, uint8_t num_dups,
       std::vector<MappingRecord> *mappings_on_diff_ref_seqs);
   void EmplaceBackMappingRecord(
       uint32_t read_id, const char *read_name, uint16_t read_length,
-      uint32_t barcode, uint32_t fragment_start_position,
+      uint64_t barcode, uint32_t fragment_start_position,
       uint16_t fragment_length, uint8_t mapq, uint8_t direction,
       uint8_t is_unique, uint8_t num_dups,
       std::vector<MappingRecord> *mappings_on_diff_ref_seqs);
   void EmplaceBackMappingRecord(
-      uint32_t read_id, const char *read_name, uint32_t cell_barcode,
+      uint32_t read_id, const char *read_name, uint64_t cell_barcode,
       uint8_t num_dups, int64_t position, int rid, int flag, uint8_t direction,
       uint8_t is_unique, uint8_t mapq, uint32_t NM, int n_cigar,
       uint32_t *cigar, std::string &MD_tag, const char *read,

--- a/src/mmcache.hpp
+++ b/src/mmcache.hpp
@@ -88,6 +88,7 @@ class mm_cache {
       cache[i].finger_print_cnt_sum = 0;
       cache[i].activated = 0;
     }
+    memset(head_mm, 0, sizeof(uint64_t) * HEAD_MM_ARRAY_SIZE);
     update_limit = 10;
     saturate_count = 100;
   }

--- a/src/output_tools.cc
+++ b/src/output_tools.cc
@@ -19,7 +19,7 @@ void OutputTools<MappingWithBarcode>::AppendMapping(
         std::string(reference_sequence_name) + "\t" +
         std::to_string(mapping.GetStartPosition()) + "\t" +
         std::to_string(mapping_end_position) + "\t" +
-        Seed2Sequence(mapping.cell_barcode_, cell_barcode_length_) + "\n");
+        barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_) + "\n");
   } else {
     std::string strand = mapping.IsPositiveStrand() ? "+" : "-";
     const char *reference_sequence_name = reference.GetSequenceNameAt(rid);
@@ -128,7 +128,7 @@ void OutputTools<PairedEndMappingWithBarcode>::AppendMapping(
         std::string(reference_sequence_name) + "\t" +
         std::to_string(mapping.GetStartPosition()) + "\t" +
         std::to_string(mapping_end_position) + "\t" +
-        Seed2Sequence(mapping.cell_barcode_, cell_barcode_length_) + "\t" +
+        barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_) + "\t" +
         std::to_string(mapping.num_dups_) + "\n");
   } else {
     bool positive_strand = mapping.IsPositiveStrand();
@@ -338,7 +338,7 @@ void OutputTools<SAMMapping>::AppendMapping(uint32_t rid,
       "\tMD:Z:" + mapping.MD_);
   if (cell_barcode_length_ > 0) {
     this->AppendMappingOutput(
-        "\tCB:Z:" + Seed2Sequence(mapping.cell_barcode_, cell_barcode_length_));
+        "\tCB:Z:" + barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_));
   }
   this->AppendMappingOutput("\n");
 }

--- a/src/output_tools.cc
+++ b/src/output_tools.cc
@@ -19,7 +19,8 @@ void OutputTools<MappingWithBarcode>::AppendMapping(
         std::string(reference_sequence_name) + "\t" +
         std::to_string(mapping.GetStartPosition()) + "\t" +
         std::to_string(mapping_end_position) + "\t" +
-        barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_) + "\n");
+        barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_) + 
+        "\t" + std::to_string(mapping.num_dups_) + "\n");
   } else {
     std::string strand = mapping.IsPositiveStrand() ? "+" : "-";
     const char *reference_sequence_name = reference.GetSequenceNameAt(rid);

--- a/src/output_tools.cc
+++ b/src/output_tools.cc
@@ -19,7 +19,7 @@ void OutputTools<MappingWithBarcode>::AppendMapping(
         std::string(reference_sequence_name) + "\t" +
         std::to_string(mapping.GetStartPosition()) + "\t" +
         std::to_string(mapping_end_position) + "\t" +
-        barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_) + 
+        barcode_translator_.Translate(mapping.cell_barcode_, cell_barcode_length_) + 
         "\t" + std::to_string(mapping.num_dups_) + "\n");
   } else {
     std::string strand = mapping.IsPositiveStrand() ? "+" : "-";
@@ -129,7 +129,7 @@ void OutputTools<PairedEndMappingWithBarcode>::AppendMapping(
         std::string(reference_sequence_name) + "\t" +
         std::to_string(mapping.GetStartPosition()) + "\t" +
         std::to_string(mapping_end_position) + "\t" +
-        barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_) + "\t" +
+        barcode_translator_.Translate(mapping.cell_barcode_, cell_barcode_length_) + "\t" +
         std::to_string(mapping.num_dups_) + "\n");
   } else {
     bool positive_strand = mapping.IsPositiveStrand();
@@ -339,7 +339,7 @@ void OutputTools<SAMMapping>::AppendMapping(uint32_t rid,
       "\tMD:Z:" + mapping.MD_);
   if (cell_barcode_length_ > 0) {
     this->AppendMappingOutput(
-        "\tCB:Z:" + barcode_translator.Translate(mapping.cell_barcode_, cell_barcode_length_));
+        "\tCB:Z:" + barcode_translator_.Translate(mapping.cell_barcode_, cell_barcode_length_));
   }
   this->AppendMappingOutput("\n");
 }

--- a/src/output_tools.h
+++ b/src/output_tools.h
@@ -21,7 +21,7 @@
 
 namespace chromap {
 
-KHASH_INIT(k64_str, uint64_t, std::string, 1, kh_int64_hash_func, kh_int64_hash_equal);
+KHASH_INIT(k64_str, uint64_t, char *, 1, kh_int64_hash_func, kh_int64_hash_equal);
 
 enum MappingOutputFormat {
   MAPPINGFORMAT_UNKNOWN,
@@ -73,7 +73,7 @@ private:
     
     int khash_return_code;
     khiter_t barcode_translate_table_iter = kh_put(k64_str, barcode_translate_table, from_seed, &khash_return_code);
-    kh_value(barcode_translate_table, barcode_translate_table_iter) = to;
+    kh_value(barcode_translate_table, barcode_translate_table_iter) = strdup(to.c_str());
   }
 
 public:
@@ -84,6 +84,12 @@ public:
   
   ~BarcodeTranslator() {
     if (barcode_translate_table != NULL) {
+      khiter_t k ;
+      for (k = kh_begin(barcode_translate_table) ; k != kh_end(barcode_translate_table); ++k)
+      {
+        if (kh_exist(barcode_translate_table, k))
+          free(kh_value(barcode_translate_table, k)) ;
+      }
       kh_destroy(k64_str, barcode_translate_table);
     }
   }
@@ -118,7 +124,7 @@ public:
         std::cerr << "Barcode does not exist in the translation table.\n" << std::endl;
         exit(-1);
       }
-      const std::string &bc_to = kh_value(barcode_translate_table, barcode_translate_table_iter);
+      std::string bc_to(kh_value(barcode_translate_table, barcode_translate_table_iter));
       if (i == 0) {
         ret = bc_to;
       } else {

--- a/src/output_tools.h
+++ b/src/output_tools.h
@@ -6,7 +6,6 @@
 #include <cinttypes>
 #include <cstring>
 #include <functional>
-#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -17,7 +16,6 @@
 #include "pairs_mapping.h"
 #include "sam_mapping.h"
 #include "sequence_batch.h"
-#include "khash.h"
 #include "barcode_translator.h"
 
 namespace chromap {

--- a/src/output_tools.h
+++ b/src/output_tools.h
@@ -18,10 +18,9 @@
 #include "sam_mapping.h"
 #include "sequence_batch.h"
 #include "khash.h"
+#include "barcode_translator.h"
 
 namespace chromap {
-
-KHASH_INIT(k64_str, uint64_t, char *, 1, kh_int64_hash_func, kh_int64_hash_equal);
 
 enum MappingOutputFormat {
   MAPPINGFORMAT_UNKNOWN,
@@ -37,103 +36,6 @@ bool ReadIdLess(const std::pair<uint32_t, MappingRecord> &a,
                 const std::pair<uint32_t, MappingRecord> &b) {
   return a.second.read_id_ < b.second.read_id_;
 }
-
-// The class for handling barcode convertion.
-class BarcodeTranslator
-{
-private:
-  khash_t(k64_str) *barcode_translate_table;
-  int from_bc_length;
-  uint64_t mask;
-
-  std::string Seed2Sequence(uint64_t seed, uint32_t seed_length) const {
-    std::string sequence;
-    sequence.reserve(seed_length);
-    uint64_t mask = 3;
-    for (uint32_t i = 0; i < seed_length; ++i) {
-      sequence.push_back(SequenceBatch::Uint8ToChar(
-          (seed >> ((seed_length - 1 - i) * 2)) & mask));
-    }
-    return sequence;
-  }
-  
-  void ProcessTranslateFileLine(std::string &line) {
-    int i;
-    int len = line.length();
-    std::string to;
-    for (i = 0; i < len; ++i) {
-      if (line[i] == ',' || line[i] == '\t')
-        break;
-    }
-
-    to = line.substr(0, i);
-    //from = line.substr(i + 1, len - i - 1);
-    from_bc_length = len - i - 1;
-    uint64_t from_seed = SequenceBatch::GenerateSeedFromSequence(line.c_str(), len, i + 1, from_bc_length);
-    
-    int khash_return_code;
-    khiter_t barcode_translate_table_iter = kh_put(k64_str, barcode_translate_table, from_seed, &khash_return_code);
-    kh_value(barcode_translate_table, barcode_translate_table_iter) = strdup(to.c_str());
-  }
-
-public:
-  BarcodeTranslator() {
-    barcode_translate_table = NULL;
-    from_bc_length = -1;
-  }
-  
-  ~BarcodeTranslator() {
-    if (barcode_translate_table != NULL) {
-      khiter_t k ;
-      for (k = kh_begin(barcode_translate_table) ; k != kh_end(barcode_translate_table); ++k)
-      {
-        if (kh_exist(barcode_translate_table, k))
-          free(kh_value(barcode_translate_table, k)) ;
-      }
-      kh_destroy(k64_str, barcode_translate_table);
-    }
-  }
-
-  void SetTranslateTable(const std::string &file) {
-    barcode_translate_table = kh_init(k64_str);
-    std::ifstream file_stream(file);
-    std::string file_line;
-    while (getline(file_stream, file_line)) {
-      ProcessTranslateFileLine(file_line); 
-    }
-    
-    mask = (1ull<<(2*from_bc_length)) - 1;
-    /*for (int i = 0; i < from_bc_length; ++i)
-    {
-      mask |= (3ull << (2*i));
-    }*/
-  }
-  
-  std::string Translate(uint64_t bc, uint32_t bc_length) {
-    if (barcode_translate_table == NULL) {
-      return Seed2Sequence(bc, bc_length);
-    } 
-
-    std::string ret;  
-    uint64_t i;
-    for (i = 0; i < bc_length / from_bc_length; ++i) {
-      uint64_t seed = (bc << (2 * i * from_bc_length)) >> (2 * (bc_length / from_bc_length - 1) * from_bc_length);
-      seed &= mask;
-      khiter_t barcode_translate_table_iter = kh_get(k64_str, barcode_translate_table, seed);
-      if (barcode_translate_table_iter == kh_end(barcode_translate_table)) {
-        std::cerr << "Barcode does not exist in the translation table.\n" << std::endl;
-        exit(-1);
-      }
-      std::string bc_to(kh_value(barcode_translate_table, barcode_translate_table_iter));
-      if (i == 0) {
-        ret = bc_to;
-      } else {
-        ret += "-" + bc_to;
-      }
-    }
-    return ret;
-  }
-};
 
 template <typename MappingRecord>
 class OutputTools {
@@ -236,7 +138,7 @@ class OutputTools {
 
   void AppendBarcodeOutput(uint64_t barcode_key) {
     fprintf(barcode_output_file_, "%s-1\n",
-            barcode_translator.Translate(barcode_key, cell_barcode_length_).data());
+            barcode_translator_.Translate(barcode_key, cell_barcode_length_).data());
             //Seed2Sequence(barcode_key, cell_barcode_length_).data());
   }
 
@@ -263,7 +165,7 @@ class OutputTools {
   }
 
   inline void SetBarcodeTranslateTable(std::string &file) {
-    barcode_translator.SetTranslateTable(file);
+    barcode_translator_.SetTranslateTable(file);
   }
 
   std::vector<int> custom_rid_rank_;  // for pairs
@@ -279,7 +181,7 @@ class OutputTools {
   FILE *peak_output_file_;
   FILE *barcode_output_file_;
   FILE *matrix_output_file_;
-  BarcodeTranslator barcode_translator;
+  BarcodeTranslator barcode_translator_;
 };
 
 // Specialization for BED format.

--- a/src/output_tools.h
+++ b/src/output_tools.h
@@ -96,11 +96,11 @@ public:
       ProcessTranslateFileLine(file_line); 
     }
     
-    mask = 0;
-    for (int i = 0; i < from_bc_length; ++i)
+    mask = (1ull<<(2*from_bc_length)) - 1;
+    /*for (int i = 0; i < from_bc_length; ++i)
     {
       mask |= (3ull << (2*i));
-    }
+    }*/
   }
   
   std::string Translate(uint64_t bc, uint32_t bc_length) {


### PR DESCRIPTION
Add the option "--barcode-translate FILE"
The file is a two-column tsv/csv file with the original barcode on the second column and the translated barcode on the first column. 
For 10x multiome, the user can put the scATAC-seq barcode on the second column and the scRNA-seq(GEX) barcode on the first column. The output barcode of Chromap will be in GEX barcode space.
The translation table also handles combinatorial barcoding, such as SHARE-seq, where each barcode is comprised of multiple segments. In the translation table, the second column will be for the each segment and the first column will be the name of that segment. In the end, the output barcode of Chromap will be "-" connected segment names. For example, a cell barcode "ATCACGTTTTGGAGGTGTCTTGGC" will be translated to "A1-D3-H12" in the output automatically.
