### PR TITLE
Fix uninitialized effective lengths for ref.

### DIFF
--- a/src/chromap.h
+++ b/src/chromap.h
@@ -19,7 +19,7 @@
 #include "sequence_batch.h"
 #include "temp_mapping.h"
 
-#define CHROMAP_VERSION "0.1.5-r302"
+#define CHROMAP_VERSION "0.1.5-r304"
 
 namespace chromap {
 

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -196,7 +196,7 @@ class SequenceBatch {
   kseq_t *sequence_kseq_;
   std::vector<kseq_t *> sequence_batch_;
   std::vector<std::string> negative_sequence_batch_;
-  int effective_range_[3];  // actual range within each sequence.
+  int effective_range_[3] = {0, -1, 1};  // actual range within each sequence.
   static constexpr uint8_t char_to_uint8_table_[256] = {
       4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
       4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,


### PR DESCRIPTION
@mourisl Please be more careful when adding uninitialized variables as they are dangerous and cause issues that are not easy to debug.