### PR TITLE
Clean up code to process mappings in low mem.

### DIFF
--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -530,7 +530,7 @@ size_t Chromap<MappingRecord>::FindBestMappingIndexFromDuplicates(
 }
 
 template <typename MappingRecord>
-void Chromap<MappingRecord>::PostProcessingInLowMemory(
+void Chromap<MappingRecord>::ProcessAndOutputMappingsInLowMemory(
     uint32_t num_mappings_in_mem, uint32_t num_reference_sequences,
     const SequenceBatch &reference,
     const MappingProcessor<MappingRecord> &mapping_processor) {
@@ -1276,8 +1276,9 @@ void Chromap<MappingRecord>::MapPairedEndReads() {
   index.Destroy();
 
   if (low_memory_mode_) {
-    PostProcessingInLowMemory(num_mappings_in_mem, num_reference_sequences,
-                              reference, mapping_processor);
+    ProcessAndOutputMappingsInLowMemory(num_mappings_in_mem,
+                                        num_reference_sequences, reference,
+                                        mapping_processor);
   } else {
     // OutputMappingStatistics(num_reference_sequences,
     // mappings_on_diff_ref_seqs_, mappings_on_diff_ref_seqs_);

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -20,7 +20,7 @@
 #include "sequence_batch.h"
 #include "temp_mapping.h"
 
-#define CHROMAP_VERSION "0.1.6-r309"
+#define CHROMAP_VERSION "0.1.6-r310"
 
 namespace chromap {
 
@@ -312,6 +312,10 @@ class Chromap {
                             int *mapping_end_position);
   int GetLongestMatchLength(const char *pattern, const char *text,
                             const int read_length);
+
+  size_t FindBestMappingIndexFromDuplicates(
+      const std::vector<MappingRecord> &duplicates);
+
   void PostProcessingInLowMemory(
       uint32_t num_mappings_in_mem, uint32_t num_reference_sequences,
       const SequenceBatch &reference,
@@ -379,6 +383,11 @@ class Chromap {
                         uint64_t &num_corrected_barcode);
 
   void BuildAugmentedTreeForPeaks(uint32_t ref_id);
+
+  void OutputTempMappings(
+      uint32_t num_reference_sequences,
+      const MappingProcessor<MappingRecord> &mapping_processor);
+
   void OutputMappingsInVector(
       uint8_t mapq_threshold, uint32_t num_reference_sequences,
       const SequenceBatch &reference,

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -316,10 +316,11 @@ class Chromap {
   size_t FindBestMappingIndexFromDuplicates(
       const std::vector<MappingRecord> &duplicates);
 
-  void PostProcessingInLowMemory(
+  void ProcessAndOutputMappingsInLowMemory(
       uint32_t num_mappings_in_mem, uint32_t num_reference_sequences,
       const SequenceBatch &reference,
       const MappingProcessor<MappingRecord> &mapping_processor);
+
   void VerifyCandidatesOnOneDirectionUsingSIMD(
       Direction candidate_direction, const SequenceBatch &read_batch,
       uint32_t read_index, const SequenceBatch &reference,

--- a/src/temp_mapping.h
+++ b/src/temp_mapping.h
@@ -21,8 +21,7 @@ namespace chromap {
 template <typename MappingRecord>
 struct TempMappingFileHandle {
   std::string file_path;
-  FILE *file;
-  bool all_loaded;
+  FILE* file;
   uint32_t num_mappings;
   uint32_t block_size;
   uint32_t current_rid;
@@ -32,14 +31,22 @@ struct TempMappingFileHandle {
   // This vector only keep mappings on the same ref seq.
   std::vector<MappingRecord> mappings;
 
-  inline void InitializeTempMappingLoading(uint32_t num_reference_sequences) {
+  inline const MappingRecord& GetCurrentMapping() const {
+    return mappings[current_mapping_index];
+  }
+
+  inline bool HasMappings() const { return num_mappings != 0; }
+
+  inline void InitializeTempMappingLoading(uint32_t temp_mapping_block_size) {
     file = fopen(file_path.c_str(), "rb");
     assert(file != NULL);
-    all_loaded = false;
+    num_mappings = 0;
+    block_size = temp_mapping_block_size;
     current_rid = 0;
+    current_mapping_index = 0;
     fread(&num_mappings_on_current_rid, sizeof(size_t), 1, file);
-    mappings.resize(block_size);
     num_loaded_mappings_on_current_rid = 0;
+    mappings.resize(block_size);
     // std::cerr << "Block size: " << block_size << ", initialize temp file " <<
     // file_path << "\n";
   }
@@ -78,11 +85,11 @@ struct TempMappingFileHandle {
           // std::cerr << "Load size " << num_mappings_on_current_rid << "\n";
           num_loaded_mappings_on_current_rid = 0;
         } else {
-          all_loaded = true;
           break;
         }
       }
     }
+
     current_mapping_index = 0;
   }
 
@@ -129,7 +136,6 @@ inline void TempMappingFileHandle<PAFMapping>::LoadTempMappingBlock(
         // std::cerr << "Load size " << num_mappings_on_current_rid << "\n";
         num_loaded_mappings_on_current_rid = 0;
       } else {
-        all_loaded = true;
         break;
       }
     }
@@ -172,7 +178,6 @@ inline void TempMappingFileHandle<PairedPAFMapping>::LoadTempMappingBlock(
         // std::cerr << "Load size " << num_mappings_on_current_rid << "\n";
         num_loaded_mappings_on_current_rid = 0;
       } else {
-        all_loaded = true;
         break;
       }
     }
@@ -215,7 +220,6 @@ inline void TempMappingFileHandle<SAMMapping>::LoadTempMappingBlock(
         // std::cerr << "Load size " << num_mappings_on_current_rid << "\n";
         num_loaded_mappings_on_current_rid = 0;
       } else {
-        all_loaded = true;
         break;
       }
     }
@@ -258,7 +262,6 @@ inline void TempMappingFileHandle<PairsMapping>::LoadTempMappingBlock(
         // std::cerr << "Load size " << num_mappings_on_current_rid << "\n";
         num_loaded_mappings_on_current_rid = 0;
       } else {
-        all_loaded = true;
         break;
       }
     }


### PR DESCRIPTION
The code to process mapping in low memory was long and hard to understand, which was bad. These changes clean up the related code a little bit, which makes it easier to maintain them and debug in the future.

On the benchmark data, this change did not affect the mapping results.