### PR TITLE
Reverse complementary SEQ and reverse QUAL for SAM.

### DIFF
--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -1824,13 +1824,13 @@ void Chromap<MappingRecord>::ProcessBestMappingsForPairedEndReadOnOneDirection(
           EmplaceBackMappingRecord(
               read_id, read1_name, barcode_key, 1, ref_start_position1, rid1,
               flag1, first_read_direction == kPositive ? 1 : 0, is_unique, mapq,
-              NM1, n_cigar1, cigar1, MD_tag1, read1,
+              NM1, n_cigar1, cigar1, MD_tag1, effect_read1,
               read_batch1.GetSequenceQualAt(pair_index),
               &(mappings_on_diff_ref_seqs[rid1]));
           EmplaceBackMappingRecord(
               read_id, read2_name, barcode_key, 1, ref_start_position2, rid2,
               flag2, second_read_direction == kPositive ? 1 : 0, is_unique,
-              mapq, NM2, n_cigar2, cigar2, MD_tag2, read2,
+              mapq, NM2, n_cigar2, cigar2, MD_tag2, effect_read2,
               read_batch2.GetSequenceQualAt(pair_index),
               &(mappings_on_diff_ref_seqs[rid2]));
         } else if (mapping_output_format_ == MAPPINGFORMAT_PAIRS) {
@@ -2965,7 +2965,7 @@ void Chromap<MappingRecord>::ProcessBestMappingsForSingleEndRead(
           }
           EmplaceBackMappingRecord(read_id, read_name, barcode_key, 1,
                                    ref_start_position, rid, flag, 0, is_unique,
-                                   mapq, NM, n_cigar, cigar, MD_tag, read,
+                                   mapq, NM, n_cigar, cigar, MD_tag, effect_read,
                                    read_batch.GetSequenceQualAt(read_index),
                                    &(mappings_on_diff_ref_seqs[rid]));
         } else if (mapping_output_format_ == MAPPINGFORMAT_PAF) {

--- a/src/sam_mapping.h
+++ b/src/sam_mapping.h
@@ -170,7 +170,7 @@ class SAMMapping : public Mapping {
     uint32_t sequence_length = GetSequenceLength();
 
     if (!IsPositiveStrand()) {
-      for (uint32_t i = 0; i < sequence_length; ++i) {
+      for (uint32_t i = 0; i < sequence_length / 2; ++i) {
         char current_qual = sequence_qual_[i];
         sequence_qual_[i] = sequence_qual_[sequence_length - 1 - i];
         sequence_qual_[sequence_length - 1 - i] = current_qual;

--- a/src/sam_mapping.h
+++ b/src/sam_mapping.h
@@ -168,6 +168,15 @@ class SAMMapping : public Mapping {
         cigar_(cigar),
         MD_(MD_tag) {
     uint32_t sequence_length = GetSequenceLength();
+
+    if (!IsPositiveStrand()) {
+      for (uint32_t i = 0; i < sequence_length; ++i) {
+        char current_qual = sequence_qual_[i];
+        sequence_qual_[i] = sequence_qual_[sequence_length - 1 - i];
+        sequence_qual_[sequence_length - 1 - i] = current_qual;
+      }
+    }
+
     if (sequence_length != sequence.length()) {
       sequence_ = sequence.substr(0, sequence_length);
       sequence_qual_ = sequence_qual.substr(0, sequence_length);


### PR DESCRIPTION
Fix an issue in #70, which was caused by not outputting reverse complementary SEQ and reverse QUAL for reads that are aligned on the reverse complementary strands.

Note that the mapping positions, CIGAR and others tags were correct. Only the SEQ and QUAL were wrong.

Now the SAM output looks good in IGV for my test datasets.