### PR TITLE
Fix warnings with clang and a wrong type conversion.

### DIFF
--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -119,9 +119,9 @@ void Chromap::TrimAdapterForPairedEndRead(uint32_t pair_index,
   int error_threshold_for_merging = 1;
   bool is_merged = false;
   for (int si = 0; si < error_threshold_for_merging + 1; ++si) {
-    int seed_start_position =
+    size_t seed_start_position =
         negative_read2.find(read1 + si * seed_length, 0, seed_length);
-    while ((uint32_t)seed_start_position != std::string::npos &&
+    while (seed_start_position != std::string::npos &&
            read2_length - seed_start_position + seed_length * si >=
                (uint32_t)min_overlap_length &&
            seed_start_position >= si * seed_length) {

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -122,9 +122,9 @@ void Chromap::TrimAdapterForPairedEndRead(uint32_t pair_index,
     size_t seed_start_position =
         negative_read2.find(read1 + si * seed_length, 0, seed_length);
     while (seed_start_position != std::string::npos &&
-           read2_length - seed_start_position + seed_length * si >=
-               (uint32_t)min_overlap_length &&
-           seed_start_position >= si * seed_length) {
+           (int)(read2_length - seed_start_position + seed_length * si) >=
+               min_overlap_length &&
+           seed_start_position >= (size_t)(si * seed_length)) {
       bool can_merge = true;
       int num_errors = 0;
       for (int i = 0; i < seed_length * si; ++i) {

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -155,7 +155,7 @@ class Chromap {
   uint64_t num_uniquely_mapped_reads_ = 0;
   uint64_t num_reads_ = 0;
   // # identical reads.
-  uint64_t num_duplicated_reads_ = 0;
+  // uint64_t num_duplicated_reads_ = 0;
 
   // For barcode stats.
   const uint64_t initial_num_sample_barcodes_ = 20000000;


### PR DESCRIPTION
This PR cause no difference on mapping results.