### PR TITLE
Add limits header for GCC 11

### DIFF
--- a/src/index.h
+++ b/src/index.h
@@ -1,6 +1,7 @@
 #ifndef INDEX_H_
 #define INDEX_H_
 
+#include <limits>
 #include <queue>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Chromap fails to compile with GCC 11 with error:
```
src/index.cc:353:12: error: ‘numeric_limits’ is not a member of ‘std’
```
This is because the `limits` header needs to be included explicitly when compiled with GCC 11. See [1]
Please note that code can still be compiled with earlier version of GCC with this patch.

Could you please include this patch?

[1] https://www.gnu.org/software/gcc/gcc-11/porting_to.html