### PR TITLE
Fix a bug during barcode reverse complement from the --read-format option; properly handle Ns in the barcode.

### DIFF
--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -341,7 +341,7 @@ void Chromap::ComputeBarcodeAbundance(uint64_t max_num_sample_barcodes) {
       for (uint32_t barcode_index = 0; barcode_index < num_loaded_barcodes;
            ++barcode_index) {
         std::vector<int> N_pos ; // position of Ns
-        barcode_batch.GetSequenceNsAt(barcode_index, true, N_pos);
+        barcode_batch.GetSequenceNsAt(barcode_index, /*little_endian=*/true, N_pos);
         if (N_pos.size() > 0) continue;
 
         uint32_t barcode_length =
@@ -419,7 +419,7 @@ bool Chromap::CorrectBarcodeAt(uint32_t barcode_index,
       kh_get(k64_seq, barcode_whitelist_lookup_table_, barcode_key);
   std::vector<int> N_pos ; // position of Ns
   
-  barcode_batch.GetSequenceNsAt(barcode_index, true, N_pos);
+  barcode_batch.GetSequenceNsAt(barcode_index, /*little_endian=*/true, N_pos);
   if (N_pos.size() > (uint32_t)mapping_parameters_.barcode_correction_error_threshold) return false;
   
   if (N_pos.size() == 0 && barcode_whitelist_lookup_table_iterator !=

--- a/src/sequence_batch.cc
+++ b/src/sequence_batch.cc
@@ -30,12 +30,12 @@ uint32_t SequenceBatch::LoadBatch() {
     if (length > 0) {
       kseq_t *sequence = sequence_batch_[sequence_index];
       std::swap(sequence_kseq_->seq, sequence->seq);
-      ReplaceByEffectiveRange(sequence->seq, true);
+      ReplaceByEffectiveRange(sequence->seq, /*is_seq=*/true);
       std::swap(sequence_kseq_->name, sequence->name);
       std::swap(sequence_kseq_->comment, sequence->comment);
       if (sequence_kseq_->qual.l != 0) {  // fastq file
         std::swap(sequence_kseq_->qual, sequence->qual);
-        ReplaceByEffectiveRange(sequence->qual, false);
+        ReplaceByEffectiveRange(sequence->qual, /*is_seq=*/false);
       }
       sequence->id = num_loaded_sequences_;
       ++num_loaded_sequences_;
@@ -71,14 +71,14 @@ bool SequenceBatch::LoadOneSequenceAndSaveAt(uint32_t sequence_index) {
   if (length > 0) {
     kseq_t *sequence = sequence_batch_[sequence_index];
     std::swap(sequence_kseq_->seq, sequence->seq);
-    ReplaceByEffectiveRange(sequence->seq, true);
+    ReplaceByEffectiveRange(sequence->seq, /*is_seq=*/true);
     std::swap(sequence_kseq_->name, sequence->name);
     std::swap(sequence_kseq_->comment, sequence->comment);
     sequence->id = num_loaded_sequences_;
     ++num_loaded_sequences_;
     if (sequence_kseq_->qual.l != 0) {  // fastq file
       std::swap(sequence_kseq_->qual, sequence->qual);
-      ReplaceByEffectiveRange(sequence->qual, false);
+      ReplaceByEffectiveRange(sequence->qual, /*is_seq=*/false);
     }
   } else {
     if (length != -1) {
@@ -104,12 +104,12 @@ uint32_t SequenceBatch::LoadAllSequences() {
       sequence_batch_.emplace_back((kseq_t *)calloc(1, sizeof(kseq_t)));
       kseq_t *sequence = sequence_batch_.back();
       std::swap(sequence_kseq_->seq, sequence->seq);
-      ReplaceByEffectiveRange(sequence->seq, true);
+      ReplaceByEffectiveRange(sequence->seq, /*is_seq=*/true);
       std::swap(sequence_kseq_->name, sequence->name);
       std::swap(sequence_kseq_->comment, sequence->comment);
       if (sequence_kseq_->qual.l != 0) {  // fastq file
         std::swap(sequence_kseq_->qual, sequence->qual);
-        ReplaceByEffectiveRange(sequence->qual, false);
+        ReplaceByEffectiveRange(sequence->qual, /*is_seq=*/false);
       }
       sequence->id = num_loaded_sequences_;
       ++num_loaded_sequences_;

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -211,7 +211,7 @@ class SequenceBatch {
   }
 
  protected:
-  void ReplaceByEffectiveRange(kstring_t &seq);
+  void ReplaceByEffectiveRange(kstring_t &seq, bool is_seq);
 
   uint32_t num_loaded_sequences_ = 0;
   uint32_t max_num_sequences_ = 0;

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -84,17 +84,18 @@ class SequenceBatch {
   // big_endian: N_pos is in the order of sequence
   // little_endian: N_pos is in the order from the sequence right side to left, 
   //                this is the order of the GenerateSeed
+  // e.g: If the sequence is "ACN", big endian returns N at 2, 
+  //      little endian returns N at 0.
   inline void GetSequenceNsAt(uint32_t sequence_index, bool little_endian, std::vector<int> &N_pos) {
-    int l = sequence_batch_[sequence_index]->seq.l;
-    char *s = sequence_batch_[sequence_index]->seq.s;
-    int i;
+    const int l = sequence_batch_[sequence_index]->seq.l;
+    const char *s = sequence_batch_[sequence_index]->seq.s;
     N_pos.clear();
     if (little_endian) {
-      for (i = l - 1; i >= 0; --i) {
+      for (int i = l - 1; i >= 0; --i) {
         if (s[i] == 'N') N_pos.push_back(l - 1 - i);
       }
     } else {
-      for (i = 0; i < l; ++i) {
+      for (int i = 0; i < l; ++i) {
         if (s[i] == 'N') N_pos.push_back(i);
       }
     }

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -165,6 +165,9 @@ class SequenceBatch {
           seed = ((seed << 2) | current_base) & mask;  // forward k-mer
         } else {
           seed = (seed << 2) & mask;  // N->A
+          if (effective_range_[2] == -1) {
+            seed |= 3ull;  // N->T if the sequence are reverse complemented
+          }
         }
       } else {
         seed = (seed << 2) & mask;  // Pad A


### PR DESCRIPTION
- Also fixed a bug that the quality score gets "complemented" when reverse.