### PR TITLE
Allow containment in adapter trimming

### DIFF
--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -134,10 +134,16 @@ void Chromap::TrimAdapterForPairedEndRead(uint32_t pair_index,
   for (int si = 0; si < error_threshold_for_merging + 1; ++si) {
     size_t seed_start_position =
         negative_read2.find(read1 + si * seed_length, 0, seed_length);
-    while (seed_start_position != std::string::npos &&
-           (int)(read2_length - seed_start_position + seed_length * si) >=
+    while (seed_start_position != std::string::npos) {
+      // The seed hit does not allow enough match based on the length
+      //   before the hit
+      if ( !((int)(read2_length - seed_start_position + seed_length * si) >=
                min_overlap_length &&
-           seed_start_position >= (size_t)(si * seed_length)) {
+           seed_start_position >= (size_t)(si * seed_length) )) {
+        seed_start_position = negative_read2.find(
+            read1 + si * seed_length, seed_start_position + 1, seed_length);
+        continue;
+      }
       bool can_merge = true;
       int num_errors = 0;
       // The bases before the seed.

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -129,14 +129,16 @@ class SequenceBatch {
 
   inline void TrimSequenceAt(uint32_t sequence_index, int length_after_trim) {
     kseq_t *sequence = sequence_batch_[sequence_index];
-    negative_sequence_batch_[sequence_index].erase(
-        negative_sequence_batch_[sequence_index].begin(),
-        negative_sequence_batch_[sequence_index].begin() + sequence->seq.l -
-            length_after_trim);
-    sequence->seq.l = length_after_trim;
-    sequence->seq.s[sequence->seq.l] = '\0';
-    sequence->qual.l = length_after_trim;
-    sequence->qual.s[sequence->qual.l] = '\0';
+    if (length_after_trim < (int)sequence->seq.l) {
+      negative_sequence_batch_[sequence_index].erase(
+          negative_sequence_batch_[sequence_index].begin(),
+          negative_sequence_batch_[sequence_index].begin() + sequence->seq.l -
+          length_after_trim);
+      sequence->seq.l = length_after_trim;
+      sequence->seq.s[sequence->seq.l] = '\0';
+      sequence->qual.l = length_after_trim;
+      sequence->qual.s[sequence->qual.l] = '\0';
+    }
   }
 
   inline void SwapSequenceBatch(SequenceBatch &batch) {

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -82,11 +82,12 @@ class SequenceBatch {
   }
 
   // big_endian: N_pos is in the order of sequence
-  // little_endian: N_pos is in the order from the sequence right side to left, 
+  // little_endian: N_pos is in the order from the sequence right side to left,
   //                this is the order of the GenerateSeed
-  // e.g: If the sequence is "ACN", big endian returns N at 2, 
+  // e.g: If the sequence is "ACN", big endian returns N at 2,
   //      little endian returns N at 0.
-  inline void GetSequenceNsAt(uint32_t sequence_index, bool little_endian, std::vector<int> &N_pos) {
+  inline void GetSequenceNsAt(uint32_t sequence_index, bool little_endian,
+                              std::vector<int> &N_pos) {
     const int l = sequence_batch_[sequence_index]->seq.l;
     const char *s = sequence_batch_[sequence_index]->seq.s;
     N_pos.clear();
@@ -129,17 +130,20 @@ class SequenceBatch {
 
   inline void TrimSequenceAt(uint32_t sequence_index, int length_after_trim) {
     kseq_t *sequence = sequence_batch_[sequence_index];
-    // The case of equality may arise when this read is contained in the mate.
-    if (length_after_trim < (int)sequence->seq.l) {
-      negative_sequence_batch_[sequence_index].erase(
-          negative_sequence_batch_[sequence_index].begin(),
-          negative_sequence_batch_[sequence_index].begin() + sequence->seq.l -
-          length_after_trim);
-      sequence->seq.l = length_after_trim;
-      sequence->seq.s[sequence->seq.l] = '\0';
-      sequence->qual.l = length_after_trim;
-      sequence->qual.s[sequence->qual.l] = '\0';
+
+    if (length_after_trim >= (int)sequence->seq.l) {
+      return;
     }
+
+    negative_sequence_batch_[sequence_index].erase(
+        negative_sequence_batch_[sequence_index].begin(),
+        negative_sequence_batch_[sequence_index].begin() + sequence->seq.l -
+            length_after_trim);
+
+    sequence->seq.l = length_after_trim;
+    sequence->seq.s[sequence->seq.l] = '\0';
+    sequence->qual.l = length_after_trim;
+    sequence->qual.s[sequence->qual.l] = '\0';
   }
 
   inline void SwapSequenceBatch(SequenceBatch &batch) {

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -129,6 +129,7 @@ class SequenceBatch {
 
   inline void TrimSequenceAt(uint32_t sequence_index, int length_after_trim) {
     kseq_t *sequence = sequence_batch_[sequence_index];
+    // The case of equality may arise when this read is contained in the mate.
     if (length_after_trim < (int)sequence->seq.l) {
       negative_sequence_batch_[sequence_index].erase(
           negative_sequence_batch_[sequence_index].begin(),


### PR DESCRIPTION
- Handle the case where one read is contained in another read in adapter trimming.
- to resolve the issue in #88 