### PR TITLE
Allow non-consecutive barcode/read sequence specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Chromap also supports user-defined barcode format, including mixed barcode and g
 data case. User can specify the sequence structure through option **--read-format**. The value
 is a comma-separated string, each field in the string is also a semi-comma-splitted string
 
-    [r1|r2|bc]:start0/start1/...:end0/end1/...:strand
-The start and end are inclusive and -1 means the end of the read. User may use '/' symbol to specify multiple segments. The strand is presented by '+' and '-' symbol, if '-' the barcode will be reverse-complemented after extraction. The strand symbol can be omitted if it is '+' and is ignored on r1 and r2. For example,
+    [r1|r2|bc]:start:end:strand
+The start and end are inclusive and -1 means the end of the read. User may use multiple fields to specify non-consecutive segments, e.g. bc:0:15,bc:32:-1. The strand is presented by '+' and '-' symbol, if '-' the barcode will be reverse-complemented after extraction. The strand symbol can be omitted if it is '+' and is ignored on r1 and r2. For example,
 when the barcode is in the first 16bp of read1, one can use the option 
 `-1 read1.fq.gz -2 read2.fq.gz --barcode read1.fq.gz --read-format bc:0:15,r1:16:-1`
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Chromap also supports user-defined barcode format, including mixed barcode and g
 data case. User can specify the sequence structure through option **--read-format**. The value
 is a comma-separated string, each field in the string is also a semi-comma-splitted string
 
-    [r1|r2|bc]:start:end:strand
-The start and end are inclusive and -1 means the end of the read. The strand is presented by '+' and '-' symbol, if '-' the barcode will be reverse-complemented after extraction. The strand symbol can be omitted if it is '+' and is ignored on r1 and r2. For example,
+    [r1|r2|bc]:start0/start1/...:end0/end1/...:strand
+The start and end are inclusive and -1 means the end of the read. User may use '/' symbol to specify multiple segments. The strand is presented by '+' and '-' symbol, if '-' the barcode will be reverse-complemented after extraction. The strand symbol can be omitted if it is '+' and is ignored on r1 and r2. For example,
 when the barcode is in the first 16bp of read1, one can use the option 
 `-1 read1.fq.gz -2 read2.fq.gz --barcode read1.fq.gz --read-format bc:0:15,r1:16:-1`
 

--- a/src/alignment.cc
+++ b/src/alignment.cc
@@ -9,8 +9,7 @@ int GetLongestMatchLength(const char *pattern, const char *text,
   int max_match = 0;
   int tmp = 0;
   for (int i = 0; i < read_length; ++i) {
-    if (SequenceBatch::CharToUint8(pattern[i]) ==
-        SequenceBatch::CharToUint8(text[i])) {
+    if (CharToUint8(pattern[i]) == CharToUint8(text[i])) {
       ++tmp;
     } else if (tmp > max_match) {
       max_match = tmp;
@@ -148,7 +147,7 @@ int BandedAlignPatternToText(int error_threshold, const char *pattern,
                              int *mapping_end_position) {
   uint32_t Peq[5] = {0, 0, 0, 0, 0};
   for (int i = 0; i < 2 * error_threshold; i++) {
-    uint8_t base = SequenceBatch::CharToUint8(pattern[i]);
+    uint8_t base = CharToUint8(pattern[i]);
     Peq[base] = Peq[base] | (1 << i);
   }
   uint32_t highest_bit_in_band_mask = 1 << (2 * error_threshold);
@@ -161,10 +160,9 @@ int BandedAlignPatternToText(int error_threshold, const char *pattern,
   uint32_t HP = 0;
   int num_errors_at_band_start_position = 0;
   for (int i = 0; i < read_length; i++) {
-    uint8_t pattern_base =
-        SequenceBatch::CharToUint8(pattern[i + 2 * error_threshold]);
+    uint8_t pattern_base = CharToUint8(pattern[i + 2 * error_threshold]);
     Peq[pattern_base] = Peq[pattern_base] | highest_bit_in_band_mask;
-    X = Peq[SequenceBatch::CharToUint8(text[i])] | VN;
+    X = Peq[CharToUint8(text[i])] | VN;
     D0 = ((VP + (X & VP)) ^ VP) | X;
     HN = VP & D0;
     HP = VN | ~(VP | D0);
@@ -207,7 +205,7 @@ int BandedAlignPatternToTextWithDropOff(int error_threshold,
                                         int *read_mapping_length) {
   uint32_t Peq[5] = {0, 0, 0, 0, 0};
   for (int i = 0; i < 2 * error_threshold; i++) {
-    uint8_t base = SequenceBatch::CharToUint8(pattern[i]);
+    uint8_t base = CharToUint8(pattern[i]);
     Peq[base] = Peq[base] | (1 << i);
   }
   uint32_t highest_bit_in_band_mask = 1 << (2 * error_threshold);
@@ -225,10 +223,9 @@ int BandedAlignPatternToTextWithDropOff(int error_threshold,
   int fail_beginning = 0;  // the alignment failed at the beginning part
   int prev_num_errors_at_band_start_position = 0;
   for (; i < read_length; i++) {
-    uint8_t pattern_base =
-        SequenceBatch::CharToUint8(pattern[i + 2 * error_threshold]);
+    uint8_t pattern_base = CharToUint8(pattern[i + 2 * error_threshold]);
     Peq[pattern_base] = Peq[pattern_base] | highest_bit_in_band_mask;
-    X = Peq[SequenceBatch::CharToUint8(text[i])] | VN;
+    X = Peq[CharToUint8(text[i])] | VN;
     D0 = ((VP + (X & VP)) ^ VP) | X;
     HN = VP & D0;
     HP = VN | ~(VP | D0);
@@ -297,8 +294,8 @@ int BandedAlignPatternToTextWithDropOffFrom3End(int error_threshold,
                                                 int *read_mapping_length) {
   uint32_t Peq[5] = {0, 0, 0, 0, 0};
   for (int i = 0; i < 2 * error_threshold; i++) {
-    uint8_t base = SequenceBatch::CharToUint8(
-        pattern[read_length + 2 * error_threshold - 1 - i]);
+    uint8_t base =
+        CharToUint8(pattern[read_length + 2 * error_threshold - 1 - i]);
     Peq[base] = Peq[base] | (1 << i);
   }
   uint32_t highest_bit_in_band_mask = 1 << (2 * error_threshold);
@@ -318,10 +315,9 @@ int BandedAlignPatternToTextWithDropOffFrom3End(int error_threshold,
   for (; i < read_length; i++) {
     // printf("%c %c %d\n", pattern[read_length - 1 - i], pattern[read_length -
     // 1 - i + error_threshold], text[read_length - 1 - i]);
-    uint8_t pattern_base =
-        SequenceBatch::CharToUint8(pattern[read_length - 1 - i]);
+    uint8_t pattern_base = CharToUint8(pattern[read_length - 1 - i]);
     Peq[pattern_base] = Peq[pattern_base] | highest_bit_in_band_mask;
-    X = Peq[SequenceBatch::CharToUint8(text[read_length - 1 - i])] | VN;
+    X = Peq[CharToUint8(text[read_length - 1 - i])] | VN;
     D0 = ((VP + (X & VP)) ^ VP) | X;
     HN = VP & D0;
     HP = VN | ~(VP | D0);
@@ -407,10 +403,10 @@ void BandedAlign4PatternsToText(int error_threshold, const char **patterns,
     Peq[ai] = _mm_setzero_si128();
   }
   for (int i = 0; i < 2 * error_threshold; i++) {
-    uint8_t base0 = SequenceBatch::CharToUint8(reference_sequence0[i]);
-    uint8_t base1 = SequenceBatch::CharToUint8(reference_sequence1[i]);
-    uint8_t base2 = SequenceBatch::CharToUint8(reference_sequence2[i]);
-    uint8_t base3 = SequenceBatch::CharToUint8(reference_sequence3[i]);
+    uint8_t base0 = CharToUint8(reference_sequence0[i]);
+    uint8_t base1 = CharToUint8(reference_sequence1[i]);
+    uint8_t base2 = CharToUint8(reference_sequence2[i]);
+    uint8_t base3 = CharToUint8(reference_sequence3[i]);
     Peq[base0] = _mm_or_si128(highest_bit_in_band_mask_vpu0, Peq[base0]);
     Peq[base1] = _mm_or_si128(highest_bit_in_band_mask_vpu1, Peq[base1]);
     Peq[base2] = _mm_or_si128(highest_bit_in_band_mask_vpu2, Peq[base2]);
@@ -432,19 +428,15 @@ void BandedAlign4PatternsToText(int error_threshold, const char **patterns,
   __m128i num_errors_at_band_start_position_vpu = _mm_setzero_si128();
   __m128i early_stop_threshold_vpu = _mm_set1_epi32(error_threshold * 3);
   for (int i = 0; i < read_length; i++) {
-    uint8_t base0 = SequenceBatch::CharToUint8(
-        reference_sequence0[i + 2 * error_threshold]);
-    uint8_t base1 = SequenceBatch::CharToUint8(
-        reference_sequence1[i + 2 * error_threshold]);
-    uint8_t base2 = SequenceBatch::CharToUint8(
-        reference_sequence2[i + 2 * error_threshold]);
-    uint8_t base3 = SequenceBatch::CharToUint8(
-        reference_sequence3[i + 2 * error_threshold]);
+    uint8_t base0 = CharToUint8(reference_sequence0[i + 2 * error_threshold]);
+    uint8_t base1 = CharToUint8(reference_sequence1[i + 2 * error_threshold]);
+    uint8_t base2 = CharToUint8(reference_sequence2[i + 2 * error_threshold]);
+    uint8_t base3 = CharToUint8(reference_sequence3[i + 2 * error_threshold]);
     Peq[base0] = _mm_or_si128(highest_bit_in_band_mask_vpu0, Peq[base0]);
     Peq[base1] = _mm_or_si128(highest_bit_in_band_mask_vpu1, Peq[base1]);
     Peq[base2] = _mm_or_si128(highest_bit_in_band_mask_vpu2, Peq[base2]);
     Peq[base3] = _mm_or_si128(highest_bit_in_band_mask_vpu3, Peq[base3]);
-    X = _mm_or_si128(Peq[SequenceBatch::CharToUint8(text[i])], VN);
+    X = _mm_or_si128(Peq[CharToUint8(text[i])], VN);
     D0 = _mm_and_si128(X, VP);
     D0 = _mm_add_epi32(D0, VP);
     D0 = _mm_xor_si128(D0, VP);
@@ -548,14 +540,14 @@ void BandedAlign8PatternsToText(int error_threshold, const char **patterns,
     Peq[ai] = _mm_setzero_si128();
   }
   for (int i = 0; i < 2 * error_threshold; i++) {
-    uint8_t base0 = SequenceBatch::CharToUint8(reference_sequence0[i]);
-    uint8_t base1 = SequenceBatch::CharToUint8(reference_sequence1[i]);
-    uint8_t base2 = SequenceBatch::CharToUint8(reference_sequence2[i]);
-    uint8_t base3 = SequenceBatch::CharToUint8(reference_sequence3[i]);
-    uint8_t base4 = SequenceBatch::CharToUint8(reference_sequence4[i]);
-    uint8_t base5 = SequenceBatch::CharToUint8(reference_sequence5[i]);
-    uint8_t base6 = SequenceBatch::CharToUint8(reference_sequence6[i]);
-    uint8_t base7 = SequenceBatch::CharToUint8(reference_sequence7[i]);
+    uint8_t base0 = CharToUint8(reference_sequence0[i]);
+    uint8_t base1 = CharToUint8(reference_sequence1[i]);
+    uint8_t base2 = CharToUint8(reference_sequence2[i]);
+    uint8_t base3 = CharToUint8(reference_sequence3[i]);
+    uint8_t base4 = CharToUint8(reference_sequence4[i]);
+    uint8_t base5 = CharToUint8(reference_sequence5[i]);
+    uint8_t base6 = CharToUint8(reference_sequence6[i]);
+    uint8_t base7 = CharToUint8(reference_sequence7[i]);
     Peq[base0] = _mm_or_si128(highest_bit_in_band_mask_vpu0, Peq[base0]);
     Peq[base1] = _mm_or_si128(highest_bit_in_band_mask_vpu1, Peq[base1]);
     Peq[base2] = _mm_or_si128(highest_bit_in_band_mask_vpu2, Peq[base2]);
@@ -581,22 +573,14 @@ void BandedAlign8PatternsToText(int error_threshold, const char **patterns,
   __m128i num_errors_at_band_start_position_vpu = _mm_setzero_si128();
   __m128i early_stop_threshold_vpu = _mm_set1_epi16(error_threshold * 3);
   for (int i = 0; i < read_length; i++) {
-    uint8_t base0 = SequenceBatch::CharToUint8(
-        reference_sequence0[i + 2 * error_threshold]);
-    uint8_t base1 = SequenceBatch::CharToUint8(
-        reference_sequence1[i + 2 * error_threshold]);
-    uint8_t base2 = SequenceBatch::CharToUint8(
-        reference_sequence2[i + 2 * error_threshold]);
-    uint8_t base3 = SequenceBatch::CharToUint8(
-        reference_sequence3[i + 2 * error_threshold]);
-    uint8_t base4 = SequenceBatch::CharToUint8(
-        reference_sequence4[i + 2 * error_threshold]);
-    uint8_t base5 = SequenceBatch::CharToUint8(
-        reference_sequence5[i + 2 * error_threshold]);
-    uint8_t base6 = SequenceBatch::CharToUint8(
-        reference_sequence6[i + 2 * error_threshold]);
-    uint8_t base7 = SequenceBatch::CharToUint8(
-        reference_sequence7[i + 2 * error_threshold]);
+    uint8_t base0 = CharToUint8(reference_sequence0[i + 2 * error_threshold]);
+    uint8_t base1 = CharToUint8(reference_sequence1[i + 2 * error_threshold]);
+    uint8_t base2 = CharToUint8(reference_sequence2[i + 2 * error_threshold]);
+    uint8_t base3 = CharToUint8(reference_sequence3[i + 2 * error_threshold]);
+    uint8_t base4 = CharToUint8(reference_sequence4[i + 2 * error_threshold]);
+    uint8_t base5 = CharToUint8(reference_sequence5[i + 2 * error_threshold]);
+    uint8_t base6 = CharToUint8(reference_sequence6[i + 2 * error_threshold]);
+    uint8_t base7 = CharToUint8(reference_sequence7[i + 2 * error_threshold]);
     Peq[base0] = _mm_or_si128(highest_bit_in_band_mask_vpu0, Peq[base0]);
     Peq[base1] = _mm_or_si128(highest_bit_in_band_mask_vpu1, Peq[base1]);
     Peq[base2] = _mm_or_si128(highest_bit_in_band_mask_vpu2, Peq[base2]);
@@ -605,7 +589,7 @@ void BandedAlign8PatternsToText(int error_threshold, const char **patterns,
     Peq[base5] = _mm_or_si128(highest_bit_in_band_mask_vpu5, Peq[base5]);
     Peq[base6] = _mm_or_si128(highest_bit_in_band_mask_vpu6, Peq[base6]);
     Peq[base7] = _mm_or_si128(highest_bit_in_band_mask_vpu7, Peq[base7]);
-    X = _mm_or_si128(Peq[SequenceBatch::CharToUint8(text[i])], VN);
+    X = _mm_or_si128(Peq[CharToUint8(text[i])], VN);
     D0 = _mm_and_si128(X, VP);
     D0 = _mm_add_epi16(D0, VP);
     D0 = _mm_xor_si128(D0, VP);
@@ -694,8 +678,8 @@ void BandedTraceback(int error_threshold, int min_num_errors,
   // if not then there are gaps so that we have to traceback with edit distance.
   uint32_t Peq[5] = {0, 0, 0, 0, 0};
   for (int i = 0; i < 2 * error_threshold; i++) {
-    uint8_t base = SequenceBatch::CharToUint8(
-        pattern[read_length - 1 + 2 * error_threshold - i]);
+    uint8_t base =
+        CharToUint8(pattern[read_length - 1 + 2 * error_threshold - i]);
     Peq[base] = Peq[base] | (1 << i);
   }
   uint32_t highest_bit_in_band_mask = 1 << (2 * error_threshold);
@@ -708,10 +692,9 @@ void BandedTraceback(int error_threshold, int min_num_errors,
   uint32_t HP = 0;
   int num_errors_at_band_start_position = 0;
   for (int i = 0; i < read_length; i++) {
-    uint8_t pattern_base =
-        SequenceBatch::CharToUint8(pattern[read_length - 1 - i]);
+    uint8_t pattern_base = CharToUint8(pattern[read_length - 1 - i]);
     Peq[pattern_base] = Peq[pattern_base] | highest_bit_in_band_mask;
-    X = Peq[SequenceBatch::CharToUint8(text[read_length - 1 - i])] | VN;
+    X = Peq[CharToUint8(text[read_length - 1 - i])] | VN;
     D0 = ((VP + (X & VP)) ^ VP) | X;
     HN = VP & D0;
     HP = VN | ~(VP | D0);
@@ -759,7 +742,7 @@ void BandedTracebackToEnd(int error_threshold, int min_num_errors,
   // if not then there are gaps so that we have to traceback with edit distance.
   uint32_t Peq[5] = {0, 0, 0, 0, 0};
   for (int i = 0; i < 2 * error_threshold; i++) {
-    uint8_t base = SequenceBatch::CharToUint8(pattern[i]);
+    uint8_t base = CharToUint8(pattern[i]);
     Peq[base] = Peq[base] | (1 << i);
   }
   uint32_t highest_bit_in_band_mask = 1 << (2 * error_threshold);
@@ -774,10 +757,9 @@ void BandedTracebackToEnd(int error_threshold, int min_num_errors,
   for (int i = 0; i < read_length; i++) {
     // printf("=>%d %d %c %c\n", i, num_errors_at_band_start_position, pattern[i
     // + 2 * error_threshold], text[i]) ;
-    uint8_t pattern_base =
-        SequenceBatch::CharToUint8(pattern[i + 2 * error_threshold]);
+    uint8_t pattern_base = CharToUint8(pattern[i + 2 * error_threshold]);
     Peq[pattern_base] = Peq[pattern_base] | highest_bit_in_band_mask;
-    X = Peq[SequenceBatch::CharToUint8(text[i])] | VN;
+    X = Peq[CharToUint8(text[i])] | VN;
     D0 = ((VP + (X & VP)) ^ VP) | X;
     HN = VP & D0;
     HP = VN | ~(VP | D0);

--- a/src/barcode_translator.h
+++ b/src/barcode_translator.h
@@ -91,8 +91,8 @@ class BarcodeTranslator {
     sequence.reserve(seed_length);
     uint64_t mask_ = 3;
     for (uint32_t i = 0; i < seed_length; ++i) {
-      sequence.push_back(SequenceBatch::Uint8ToChar(
-          (seed >> ((seed_length - 1 - i) * 2)) & mask_));
+      sequence.push_back(
+          Uint8ToChar((seed >> ((seed_length - 1 - i) * 2)) & mask_));
     }
     return sequence;
   }

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -526,9 +526,9 @@ bool Chromap::CorrectBarcodeAt(uint32_t barcode_index,
           adjusted_qual = adjusted_qual < 3 ? 3 : adjusted_qual;
           double score =
               pow(10.0, ((-adjusted_qual) / 10.0)) * barcode_abundance;
-          corrected_barcodes_with_quals.emplace_back(BarcodeWithQual{
-              barcode_length - 1 - i,
-              SequenceBatch::Uint8ToChar(base_to_change1), 0, 0, score});
+          corrected_barcodes_with_quals.emplace_back(
+              BarcodeWithQual{barcode_length - 1 - i,
+                              Uint8ToChar(base_to_change1), 0, 0, score});
           // std::cerr << "1score: " << score << " pos1: " << barcode_length - 1
           // - i << " b1: " << base_to_change1 << " pos2: " << 0 << " b2: " <<
           // (char)0 << "\n";
@@ -579,10 +579,9 @@ bool Chromap::CorrectBarcodeAt(uint32_t barcode_index,
                 double score =
                     pow(10.0, ((-adjusted_qual) / 10.0)) * barcode_abundance;
                 corrected_barcodes_with_quals.emplace_back(BarcodeWithQual{
-                    barcode_length - 1 - i,
-                    SequenceBatch::Uint8ToChar(base_to_change1),
-                    barcode_length - 1 - j,
-                    SequenceBatch::Uint8ToChar(base_to_change2), score});
+                    barcode_length - 1 - i, Uint8ToChar(base_to_change1),
+                    barcode_length - 1 - j, Uint8ToChar(base_to_change2),
+                    score});
                 // std::cerr << "2score: " << score << " pos1: " <<
                 // barcode_length - 1 - i << " b1: " << base_to_change1 << "
                 // pos2: " << barcode_length - 1 -j << " b2: " <<
@@ -719,23 +718,23 @@ void Chromap::ParseReadFormat(const std::string &read_format) {
   read1_format_.Init();
   read2_format_.Init();
   barcode_format_.Init();
-  for (i = 0; i < read_format.size(); ) {
-    for (j = i + 1; j < read_format.size() && j != ','; ++j) 
+  for (i = 0; i < read_format.size();) {
+    for (j = i + 1; j < read_format.size() && j != ','; ++j)
       ;
     bool parse_success = true;
     if (read_format[i] == 'r' && read_format[i + 1] == '1') {
-      parse_success = read1_format_.ParseEffectiveRange(
-                read_format.c_str() + i, j - i);
+      parse_success =
+          read1_format_.ParseEffectiveRange(read_format.c_str() + i, j - i);
     } else if (read_format[i] == 'r' && read_format[i + 1] == '2') {
-      parse_success = read2_format_.ParseEffectiveRange(
-                read_format.c_str() + i, j - i);
+      parse_success =
+          read2_format_.ParseEffectiveRange(read_format.c_str() + i, j - i);
     } else if (read_format[i] == 'b' && read_format[i + 1] == 'c') {
-      parse_success = barcode_format_.ParseEffectiveRange(
-                read_format.c_str() + i, j - i);
+      parse_success =
+          barcode_format_.ParseEffectiveRange(read_format.c_str() + i, j - i);
     } else {
       parse_success = false;
     }
-    if (!parse_success) 
+    if (!parse_success)
       ExitWithMessage("Unknown read format: " + read_format + "\n");
     i = j;
   }

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -301,7 +301,7 @@ uint32_t Chromap::SampleInputBarcodesAndExamineLength() {
   uint32_t sample_batch_size = 1000;
   SequenceBatch barcode_batch(sample_batch_size);
 
-  barcode_batch.SetSeqEffectiveRange(barcode_format_);
+  barcode_batch.SetSeqEffectiveRange(barcode_effective_range_);
 
   barcode_batch.InitializeLoading(mapping_parameters_.barcode_file_paths[0]);
 
@@ -382,7 +382,7 @@ void Chromap::LoadBarcodeWhitelist() {
 void Chromap::ComputeBarcodeAbundance(uint64_t max_num_sample_barcodes) {
   double real_start_time = GetRealTime();
   SequenceBatch barcode_batch(read_batch_size_);
-  barcode_batch.SetSeqEffectiveRange(barcode_format_);
+  barcode_batch.SetSeqEffectiveRange(barcode_effective_range_);
   for (size_t read_file_index = 0;
        read_file_index < mapping_parameters_.read_file1_paths.size();
        ++read_file_index) {
@@ -715,22 +715,22 @@ void Chromap::OutputMappingStatistics() {
 
 void Chromap::ParseReadFormat(const std::string &read_format) {
   uint32_t i, j;
-  read1_format_.Init();
-  read2_format_.Init();
-  barcode_format_.Init();
+  read1_effective_range_.Init();
+  read2_effective_range_.Init();
+  barcode_effective_range_.Init();
   for (i = 0; i < read_format.size();) {
     for (j = i + 1; j < read_format.size() && j != ','; ++j)
       ;
     bool parse_success = true;
     if (read_format[i] == 'r' && read_format[i + 1] == '1') {
-      parse_success =
-          read1_format_.ParseEffectiveRange(read_format.c_str() + i, j - i);
+      parse_success = read1_effective_range_.ParseEffectiveRange(
+          read_format.c_str() + i, j - i);
     } else if (read_format[i] == 'r' && read_format[i + 1] == '2') {
-      parse_success =
-          read2_format_.ParseEffectiveRange(read_format.c_str() + i, j - i);
+      parse_success = read2_effective_range_.ParseEffectiveRange(
+          read_format.c_str() + i, j - i);
     } else if (read_format[i] == 'b' && read_format[i + 1] == 'c') {
-      parse_success =
-          barcode_format_.ParseEffectiveRange(read_format.c_str() + i, j - i);
+      parse_success = barcode_effective_range_.ParseEffectiveRange(
+          read_format.c_str() + i, j - i);
     } else {
       parse_success = false;
     }

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -711,6 +711,10 @@ void Chromap::OutputMappingStatistics() {
 }
 
 void Chromap::ParseReadFormat(const std::string &read_format) {
+  if (read_format.empty()) {
+    return;
+  }
+
   read1_effective_range_.InitializeParsing();
   read2_effective_range_.InitializeParsing();
   barcode_effective_range_.InitializeParsing();

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -714,13 +714,15 @@ void Chromap::OutputMappingStatistics() {
 }
 
 void Chromap::ParseReadFormat(const std::string &read_format) {
-  uint32_t i, j;
   read1_effective_range_.Init();
   read2_effective_range_.Init();
   barcode_effective_range_.Init();
+
+  uint32_t i, j;
   for (i = 0; i < read_format.size();) {
     for (j = i + 1; j < read_format.size() && j != ','; ++j)
       ;
+
     bool parse_success = true;
     if (read_format[i] == 'r' && read_format[i + 1] == '1') {
       parse_success = read1_effective_range_.ParseEffectiveRange(
@@ -734,8 +736,11 @@ void Chromap::ParseReadFormat(const std::string &read_format) {
     } else {
       parse_success = false;
     }
-    if (!parse_success)
+
+    if (!parse_success) {
       ExitWithMessage("Unknown read format: " + read_format + "\n");
+    }
+
     i = j;
   }
 }

--- a/src/chromap.cc
+++ b/src/chromap.cc
@@ -720,9 +720,8 @@ void Chromap::ParseReadFormat(const std::string &read_format) {
 
   uint32_t i, j;
   for (i = 0; i < read_format.size();) {
-    for (j = i + 1; j < read_format.size() && j != ','; ++j)
+    for (j = i + 1; j < read_format.size() && read_format[j] != ','; ++j)
       ;
-
     bool parse_success = true;
     if (read_format[i] == 'r' && read_format[i + 1] == '1') {
       parse_success = read1_effective_range_.ParseEffectiveRange(
@@ -741,7 +740,7 @@ void Chromap::ParseReadFormat(const std::string &read_format) {
       ExitWithMessage("Unknown read format: " + read_format + "\n");
     }
 
-    i = j;
+    i = j + 1;
   }
 }
 

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -312,8 +312,9 @@ void Chromap::MapSingleEndReads() {
                 read_batch_for_loading, barcode_batch_for_loading);
           }  // end of openmp loading task
           uint32_t history_update_threshold =
-            mm_to_candidates_cache.GetUpdateThreshold(num_loaded_reads, num_reads_, false);
-             // int grain_size = 10000;
+              mm_to_candidates_cache.GetUpdateThreshold(num_loaded_reads,
+                                                        num_reads_, false);
+          // int grain_size = 10000;
 //#pragma omp taskloop grainsize(grain_size) //num_tasks(num_threads_* 50)
 #pragma omp taskloop num_tasks( \
     mapping_parameters_.num_threads *mapping_parameters_.num_threads)
@@ -351,7 +352,7 @@ void Chromap::MapSingleEndReads() {
                     mapping_parameters_.error_threshold, index,
                     mapping_metadata);
               }
-              
+
               if (read_index < history_update_threshold) {
                 mm_history[read_index].timestamp = num_reads_;
                 mm_history[read_index].minimizers =
@@ -702,7 +703,8 @@ void Chromap::MapPairedEndReads() {
 
           int grain_size = 5000;
           uint32_t history_update_threshold =
-            mm_to_candidates_cache.GetUpdateThreshold(num_loaded_pairs, num_reads_, true);
+              mm_to_candidates_cache.GetUpdateThreshold(num_loaded_pairs,
+                                                        num_reads_, true);
 #pragma omp taskloop grainsize(grain_size)
           for (uint32_t pair_index = 0; pair_index < num_loaded_pairs;
                ++pair_index) {
@@ -917,7 +919,7 @@ void Chromap::MapPairedEndReads() {
           //}
 #pragma omp taskwait
           // Update cache
-          for (uint32_t pair_index = 0; pair_index < history_update_threshold ;
+          for (uint32_t pair_index = 0; pair_index < history_update_threshold;
                ++pair_index) {
             if (mm_history1[pair_index].timestamp != num_reads_) continue;
 

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -23,6 +23,7 @@
 #include "mmcache.hpp"
 #include "paired_end_mapping_metadata.h"
 #include "sequence_batch.h"
+#include "sequence_effective_range.h"
 #include "temp_mapping.h"
 #include "utils.h"
 
@@ -184,14 +185,12 @@ void Chromap::MapSingleEndReads() {
   int kmer_size = index.GetKmerSize();
   // index.Statistics(num_sequences, reference);
 
-  SequenceBatch read_batch(read_batch_size_);
-  SequenceBatch read_batch_for_loading(read_batch_size_);
-  SequenceBatch barcode_batch(read_batch_size_);
-  SequenceBatch barcode_batch_for_loading(read_batch_size_);
-  read_batch.SetSeqEffectiveRange(read1_effective_range_);
-  read_batch_for_loading.SetSeqEffectiveRange(read1_effective_range_);
-  barcode_batch.SetSeqEffectiveRange(barcode_effective_range_);
-  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_effective_range_);
+  SequenceBatch read_batch(read_batch_size_, read1_effective_range_);
+  SequenceBatch read_batch_for_loading(read_batch_size_,
+                                       read1_effective_range_);
+  SequenceBatch barcode_batch(read_batch_size_, barcode_effective_range_);
+  SequenceBatch barcode_batch_for_loading(read_batch_size_,
+                                          barcode_effective_range_);
 
   std::vector<std::vector<MappingRecord>> mappings_on_diff_ref_seqs;
   mappings_on_diff_ref_seqs.reserve(num_reference_sequences);
@@ -552,19 +551,15 @@ void Chromap::MapPairedEndReads() {
   // index.Statistics(num_sequences, reference);
 
   // Initialize read batches
-  SequenceBatch read_batch1(read_batch_size_);
-  SequenceBatch read_batch2(read_batch_size_);
-  SequenceBatch barcode_batch(read_batch_size_);
-  SequenceBatch read_batch1_for_loading(read_batch_size_);
-  SequenceBatch read_batch2_for_loading(read_batch_size_);
-  SequenceBatch barcode_batch_for_loading(read_batch_size_);
-
-  read_batch1.SetSeqEffectiveRange(read1_effective_range_);
-  read_batch2.SetSeqEffectiveRange(read2_effective_range_);
-  barcode_batch.SetSeqEffectiveRange(barcode_effective_range_);
-  read_batch1_for_loading.SetSeqEffectiveRange(read1_effective_range_);
-  read_batch2_for_loading.SetSeqEffectiveRange(read2_effective_range_);
-  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_effective_range_);
+  SequenceBatch read_batch1(read_batch_size_, read1_effective_range_);
+  SequenceBatch read_batch2(read_batch_size_, read2_effective_range_);
+  SequenceBatch barcode_batch(read_batch_size_, barcode_effective_range_);
+  SequenceBatch read_batch1_for_loading(read_batch_size_,
+                                        read1_effective_range_);
+  SequenceBatch read_batch2_for_loading(read_batch_size_,
+                                        read2_effective_range_);
+  SequenceBatch barcode_batch_for_loading(read_batch_size_,
+                                          barcode_effective_range_);
 
   // Initialize cache
   mm_cache mm_to_candidates_cache(2000003);

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -132,9 +132,9 @@ class Chromap {
   const uint32_t read_batch_size_ = 500000;
 
   // 0-start, 1-end (includsive), 2-strand(-1:minus, 1:plus)
-  int barcode_format_[3];
-  int read1_format_[3];
-  int read2_format_[3];
+  SequenceEffectiveRange barcode_format_;
+  SequenceEffectiveRange read1_format_;
+  SequenceEffectiveRange read2_format_;
 
   std::vector<int> custom_rid_rank_;
   std::vector<int> pairs_custom_rid_rank_;
@@ -188,13 +188,10 @@ void Chromap::MapSingleEndReads() {
   SequenceBatch read_batch_for_loading(read_batch_size_);
   SequenceBatch barcode_batch(read_batch_size_);
   SequenceBatch barcode_batch_for_loading(read_batch_size_);
-  read_batch.SetSeqEffectiveRange(read1_format_[0], read1_format_[1], 1);
-  read_batch_for_loading.SetSeqEffectiveRange(read1_format_[0],
-                                              read1_format_[1], 1);
-  barcode_batch.SetSeqEffectiveRange(barcode_format_[0], barcode_format_[1],
-                                     barcode_format_[2]);
-  barcode_batch_for_loading.SetSeqEffectiveRange(
-      barcode_format_[0], barcode_format_[1], barcode_format_[2]);
+  read_batch.SetSeqEffectiveRange(read1_format_);
+  read_batch_for_loading.SetSeqEffectiveRange(read1_format_);
+  barcode_batch.SetSeqEffectiveRange(barcode_format_);
+  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_format_);
 
   std::vector<std::vector<MappingRecord>> mappings_on_diff_ref_seqs;
   mappings_on_diff_ref_seqs.reserve(num_reference_sequences);
@@ -561,16 +558,12 @@ void Chromap::MapPairedEndReads() {
   SequenceBatch read_batch2_for_loading(read_batch_size_);
   SequenceBatch barcode_batch_for_loading(read_batch_size_);
 
-  read_batch1.SetSeqEffectiveRange(read1_format_[0], read1_format_[1], 1);
-  read_batch2.SetSeqEffectiveRange(read2_format_[0], read2_format_[1], 1);
-  barcode_batch.SetSeqEffectiveRange(barcode_format_[0], barcode_format_[1],
-                                     barcode_format_[2]);
-  read_batch1_for_loading.SetSeqEffectiveRange(read1_format_[0],
-                                               read1_format_[1], 1);
-  read_batch2_for_loading.SetSeqEffectiveRange(read2_format_[0],
-                                               read2_format_[1], 1);
-  barcode_batch_for_loading.SetSeqEffectiveRange(
-      barcode_format_[0], barcode_format_[1], barcode_format_[2]);
+  read_batch1.SetSeqEffectiveRange(read1_format_);
+  read_batch2.SetSeqEffectiveRange(read2_format_);
+  barcode_batch.SetSeqEffectiveRange(barcode_format_);
+  read_batch1_for_loading.SetSeqEffectiveRange(read1_format_);
+  read_batch2_for_loading.SetSeqEffectiveRange(read2_format_);
+  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_format_);
 
   // Initialize cache
   mm_cache mm_to_candidates_cache(2000003);

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -132,9 +132,9 @@ class Chromap {
   const uint32_t read_batch_size_ = 500000;
 
   // 0-start, 1-end (includsive), 2-strand(-1:minus, 1:plus)
-  SequenceEffectiveRange barcode_format_;
-  SequenceEffectiveRange read1_format_;
-  SequenceEffectiveRange read2_format_;
+  SequenceEffectiveRange barcode_effective_range_;
+  SequenceEffectiveRange read1_effective_range_;
+  SequenceEffectiveRange read2_effective_range_;
 
   std::vector<int> custom_rid_rank_;
   std::vector<int> pairs_custom_rid_rank_;
@@ -188,10 +188,10 @@ void Chromap::MapSingleEndReads() {
   SequenceBatch read_batch_for_loading(read_batch_size_);
   SequenceBatch barcode_batch(read_batch_size_);
   SequenceBatch barcode_batch_for_loading(read_batch_size_);
-  read_batch.SetSeqEffectiveRange(read1_format_);
-  read_batch_for_loading.SetSeqEffectiveRange(read1_format_);
-  barcode_batch.SetSeqEffectiveRange(barcode_format_);
-  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_format_);
+  read_batch.SetSeqEffectiveRange(read1_effective_range_);
+  read_batch_for_loading.SetSeqEffectiveRange(read1_effective_range_);
+  barcode_batch.SetSeqEffectiveRange(barcode_effective_range_);
+  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_effective_range_);
 
   std::vector<std::vector<MappingRecord>> mappings_on_diff_ref_seqs;
   mappings_on_diff_ref_seqs.reserve(num_reference_sequences);
@@ -559,12 +559,12 @@ void Chromap::MapPairedEndReads() {
   SequenceBatch read_batch2_for_loading(read_batch_size_);
   SequenceBatch barcode_batch_for_loading(read_batch_size_);
 
-  read_batch1.SetSeqEffectiveRange(read1_format_);
-  read_batch2.SetSeqEffectiveRange(read2_format_);
-  barcode_batch.SetSeqEffectiveRange(barcode_format_);
-  read_batch1_for_loading.SetSeqEffectiveRange(read1_format_);
-  read_batch2_for_loading.SetSeqEffectiveRange(read2_format_);
-  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_format_);
+  read_batch1.SetSeqEffectiveRange(read1_effective_range_);
+  read_batch2.SetSeqEffectiveRange(read2_effective_range_);
+  barcode_batch.SetSeqEffectiveRange(barcode_effective_range_);
+  read_batch1_for_loading.SetSeqEffectiveRange(read1_effective_range_);
+  read_batch2_for_loading.SetSeqEffectiveRange(read2_effective_range_);
+  barcode_batch_for_loading.SetSeqEffectiveRange(barcode_effective_range_);
 
   // Initialize cache
   mm_cache mm_to_candidates_cache(2000003);

--- a/src/index.cc
+++ b/src/index.cc
@@ -622,7 +622,7 @@ void Index::GenerateMinimizerSketch(
   int min_position = 0;
 
   for (uint32_t position = 0; position < sequence_length; ++position) {
-    uint8_t current_base = SequenceBatch::CharToUint8(sequence[position]);
+    uint8_t current_base = CharToUint8(sequence[position]);
     std::pair<uint64_t, uint64_t> current_seed = {UINT64_MAX, UINT64_MAX};
     if (current_base < 4) {
       // Not an ambiguous base.

--- a/src/ksw.cc
+++ b/src/ksw.cc
@@ -517,7 +517,7 @@ int ksw_semi_global3(int qlen, const char *query, int tlen, const char *target, 
 	// generate the query profile
 	for (k = i = 0; k < m; ++k) {
 		const int8_t *p = &mat[k * m];
-		for (j = 0; j < qlen; ++j) qp[i++] = p[chromap::SequenceBatch::CharToUint8(query[j])];
+		for (j = 0; j < qlen; ++j) qp[i++] = p[chromap::CharToUint8(query[j])];
 	}
 	// fill the first row
 	eh[0].h = 0; eh[0].e = MINUS_INF;
@@ -528,7 +528,7 @@ int ksw_semi_global3(int qlen, const char *query, int tlen, const char *target, 
 	// DP loop
 	for (i = 0; LIKELY(i < tlen); ++i) { // target sequence is in the outer loop
 		int32_t f = MINUS_INF, h1, beg, end, t;
-		int8_t *q = &qp[chromap::SequenceBatch::CharToUint8(target[i]) * qlen];
+		int8_t *q = &qp[chromap::CharToUint8(target[i]) * qlen];
 		//beg = i > w? i - w : 0;
 		beg = i; 
 		//beg = i > 1? i - 1 : 0;

--- a/src/sequence_batch.cc
+++ b/src/sequence_batch.cc
@@ -138,31 +138,7 @@ void SequenceBatch::FinalizeLoading() {
 }
 
 void SequenceBatch::ReplaceByEffectiveRange(kstring_t &seq, bool is_seq) {
-  if (effective_range_[0] == 0 && effective_range_[1] == -1 &&
-      effective_range_[2] == 1) {
-    return;
-  }
-  int i, j;
-  int start = effective_range_[0];
-  int end = effective_range_[1];
-  if (effective_range_[1] == -1) end = seq.l - 1;
-  for (i = 0; i < end - start + 1; ++i) {
-    seq.s[i] = seq.s[start + i];
-  }
-  seq.s[i] = '\0';
-  seq.l = end - start + 1;
-  if (effective_range_[2] == -1) {
-    if (is_seq) {
-      for (i = 0; i < (int)seq.l; ++i) {
-        seq.s[i] = Uint8ToChar(((uint8_t)3) ^ (CharToUint8(seq.s[i])));
-      }
-    }
-    for (i = 0, j = seq.l - 1; i < j; ++i, --j) {
-      char tmp = seq.s[i];
-      seq.s[i] = seq.s[j];
-      seq.s[j] = tmp;
-    }
-  }
+  seq.l = effective_range_.Replace(seq.s, seq.l, is_seq);
 }
 
 }  // namespace chromap

--- a/src/sequence_batch.cc
+++ b/src/sequence_batch.cc
@@ -6,9 +6,6 @@
 
 namespace chromap {
 
-constexpr uint8_t SequenceBatch::char_to_uint8_table_[256];
-constexpr char SequenceBatch::uint8_to_char_table_[8];
-
 void SequenceBatch::InitializeLoading(const std::string &sequence_file_path) {
   sequence_file_ = gzopen(sequence_file_path.c_str(), "r");
   if (sequence_file_ == NULL) {

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -17,18 +17,19 @@ namespace chromap {
 class SequenceBatch {
  public:
   KSEQ_INIT(gzFile, gzread);
-  SequenceBatch() { effective_range_.Init(); }
+  SequenceBatch() = default;
 
   // Construct once and use update sequences when loading each batch.
-  SequenceBatch(uint32_t max_num_sequences)
-      : max_num_sequences_(max_num_sequences) {
+  SequenceBatch(uint32_t max_num_sequences,
+                const SequenceEffectiveRange &effective_range)
+      : max_num_sequences_(max_num_sequences),
+        effective_range_(effective_range) {
     sequence_batch_.reserve(max_num_sequences_);
     for (uint32_t i = 0; i < max_num_sequences_; ++i) {
       sequence_batch_.emplace_back((kseq_t *)calloc(1, sizeof(kseq_t)));
       sequence_batch_.back()->f = NULL;
     }
     negative_sequence_batch_.assign(max_num_sequences_, "");
-    effective_range_.Init();
   }
 
   ~SequenceBatch() {
@@ -96,10 +97,6 @@ class SequenceBatch {
         if (s[i] == 'N') N_pos.push_back(i);
       }
     }
-  }
-
-  inline void SetSeqEffectiveRange(const SequenceEffectiveRange &range) {
-    effective_range_ = range;
   }
 
   //  inline char GetReverseComplementBaseOfSequenceAt(uint32_t sequence_index,
@@ -231,7 +228,7 @@ class SequenceBatch {
   std::vector<std::string> negative_sequence_batch_;
 
   // Actual range within each sequence.
-  SequenceEffectiveRange effective_range_;
+  const SequenceEffectiveRange effective_range_;
   void ReplaceByEffectiveRange(kstring_t &seq, bool is_seq);
 };
 

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -17,7 +17,7 @@ namespace chromap {
 class SequenceBatch {
  public:
   KSEQ_INIT(gzFile, gzread);
-  SequenceBatch() = default;
+  SequenceBatch() : effective_range_(SequenceEffectiveRange()) {}
 
   // Construct once and use update sequences when loading each batch.
   SequenceBatch(uint32_t max_num_sequences,

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "kseq.h"
+#include "sequence_effective_range.h"
 
 namespace chromap {
 
@@ -16,9 +17,7 @@ class SequenceBatch {
  public:
   KSEQ_INIT(gzFile, gzread);
   SequenceBatch() {
-    effective_range_[0] = 0;
-    effective_range_[1] = -1;
-    effective_range_[2] = 1;
+    effective_range_.Init();
   }
 
   // Construct once and use update sequences when loading each batch.
@@ -30,9 +29,7 @@ class SequenceBatch {
       sequence_batch_.back()->f = NULL;
     }
     negative_sequence_batch_.assign(max_num_sequences_, "");
-    effective_range_[0] = 0;
-    effective_range_[1] = -1;
-    effective_range_[2] = 1;
+    effective_range_.Init();
   }
 
   ~SequenceBatch() {
@@ -102,10 +99,8 @@ class SequenceBatch {
     }
   }
 
-  inline void SetSeqEffectiveRange(int start, int end, int strand) {
-    effective_range_[0] = start;
-    effective_range_[1] = end;
-    effective_range_[2] = strand;
+  inline void SetSeqEffectiveRange(const SequenceEffectiveRange &range) {
+    effective_range_ = range;
   }
 
   //  inline char GetReverseComplementBaseOfSequenceAt(uint32_t sequence_index,
@@ -247,7 +242,7 @@ class SequenceBatch {
   kseq_t *sequence_kseq_ = nullptr;
   std::vector<kseq_t *> sequence_batch_;
   std::vector<std::string> negative_sequence_batch_;
-  int effective_range_[3] = {0, -1, 1};  // actual range within each sequence.
+  SequenceEffectiveRange effective_range_;  // actual range within each sequence.
 
   static constexpr uint8_t char_to_uint8_table_[256] = {
       4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,

--- a/src/sequence_batch.h
+++ b/src/sequence_batch.h
@@ -10,15 +10,14 @@
 
 #include "kseq.h"
 #include "sequence_effective_range.h"
+#include "utils.h"
 
 namespace chromap {
 
 class SequenceBatch {
  public:
   KSEQ_INIT(gzFile, gzread);
-  SequenceBatch() {
-    effective_range_.Init();
-  }
+  SequenceBatch() { effective_range_.Init(); }
 
   // Construct once and use update sequences when loading each batch.
   SequenceBatch(uint32_t max_num_sequences)
@@ -164,14 +163,6 @@ class SequenceBatch {
     sequence->seq.s[base_position] = correct_base;
   }
 
-  inline static uint8_t CharToUint8(const char c) {
-    return char_to_uint8_table_[(uint8_t)c];
-  }
-
-  inline static char Uint8ToChar(const uint8_t i) {
-    return uint8_to_char_table_[i];
-  }
-
   inline uint64_t GenerateSeedFromSequenceAt(uint32_t sequence_index,
                                              uint32_t start_position,
                                              uint32_t seed_length) const {
@@ -181,8 +172,7 @@ class SequenceBatch {
     uint64_t seed = 0;
     for (uint32_t i = 0; i < seed_length; ++i) {
       if (start_position + i < sequence_length) {
-        uint8_t current_base =
-            SequenceBatch::CharToUint8(sequence[i + start_position]);
+        uint8_t current_base = CharToUint8(sequence[i + start_position]);
         if (current_base < 4) {                        // not an ambiguous base
           seed = ((seed << 2) | current_base) & mask;  // forward k-mer
         } else {
@@ -203,8 +193,7 @@ class SequenceBatch {
     uint64_t seed = 0;
     for (uint32_t i = 0; i < seed_length; ++i) {
       if (start_position + i < sequence_length) {
-        uint8_t current_base =
-            SequenceBatch::CharToUint8(sequence[i + start_position]);
+        uint8_t current_base = CharToUint8(sequence[i + start_position]);
         if (current_base < 4) {                        // not an ambiguous base
           seed = ((seed << 2) | current_base) & mask;  // forward k-mer
         } else {
@@ -233,8 +222,6 @@ class SequenceBatch {
   }
 
  protected:
-  void ReplaceByEffectiveRange(kstring_t &seq, bool is_seq);
-
   uint32_t num_loaded_sequences_ = 0;
   uint32_t max_num_sequences_ = 0;
   uint64_t num_bases_ = 0;
@@ -242,22 +229,10 @@ class SequenceBatch {
   kseq_t *sequence_kseq_ = nullptr;
   std::vector<kseq_t *> sequence_batch_;
   std::vector<std::string> negative_sequence_batch_;
-  SequenceEffectiveRange effective_range_;  // actual range within each sequence.
 
-  static constexpr uint8_t char_to_uint8_table_[256] = {
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-  static constexpr char uint8_to_char_table_[8] = {'A', 'C', 'G', 'T',
-                                                   'N', 'N', 'N', 'N'};
+  // Actual range within each sequence.
+  SequenceEffectiveRange effective_range_;
+  void ReplaceByEffectiveRange(kstring_t &seq, bool is_seq);
 };
 
 }  // namespace chromap

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -75,19 +75,10 @@ class SequenceEffectiveRange {
     return true;
   }
 
-  // Check whether the effective range is the full range
-  bool IsFullRange() {
-    if (strand == '+' && starts[0] == 0 && ends[0] == -1) {
-      return true;
-    }
-
-    return false;
-  }
-
   // Replace by the range specified in the starts, ends section, but does not
   // apply the strand operation. Return new length.
   int Replace(char *s, int len, bool need_complement) {
-    if (IsFullRange()) {
+    if (IsFullRangeAndPositiveStrand()) {
       return len;
     }
 
@@ -127,6 +118,14 @@ class SequenceEffectiveRange {
   }
 
  private:
+  bool IsFullRangeAndPositiveStrand() {
+    if (strand == '+' && starts[0] == 0 && ends[0] == -1) {
+      return true;
+    }
+
+    return false;
+  }
+
   std::vector<int> starts;
   std::vector<int> ends;
   // The barcode will be reverse-complemented after extraction if strand is '-'.

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -1,0 +1,134 @@
+#ifndef SEQUENCEEFFECTIVERANGE_H_
+#define SEQUENCEEFFECTIVERANGE_H_
+
+#include <algorithm>
+#include <vector>
+
+#include <stdlib.h>
+
+namespace chromap {
+
+// The class handles the custom read format indicating 
+// the effective range on a sequence.
+class SequenceEffectiveRange {
+ public:
+  SequenceEffectiveRange() {}
+  ~SequenceEffectiveRange() {}
+
+  void Init() {
+    starts.push_back(0);
+    ends.push_back(-1);
+    strand = 1;
+    range_num = 1;
+  }
+  
+  // Return: false - fail to parse
+  bool ParseEffectiveRange(const char *s, int len) {
+    int i;
+    int j = 0; // start, end, strand section
+    char buffer[20];
+    int blen = 0;
+    starts.clear();
+    ends.clear();
+    strand = 1;
+    for (i = 3; i <= len; ++i) {
+      if (i == len || s[i] == '/' || s[i] == ':') {
+        buffer[blen] = '\0';
+        if (j == 0) 
+          starts.push_back(atoi(buffer));
+        else if (j == 1)
+          ends.push_back(atoi(buffer));
+        else 
+          strand = buffer[0] == '+' ? 1 : -1;
+        blen = 0;
+        if (i < len && s[i] == ':')
+          ++j;
+      } else {
+        buffer[blen] = s[i];
+        ++blen;
+      }
+    }
+    if (j >= 3 || starts.size() != ends.size())
+      return false;
+    std::sort(starts.begin(), starts.end());
+    std::sort(ends.begin(), ends.end());
+    range_num = starts.size();
+    if (ends[0] == -1) {
+      for (i = 0; i < range_num - 1; ++i)  
+        ends[i] = ends[i + 1];
+      ends[i] = -1;
+    }
+    return true;
+  }
+
+  // Check whether the effective range is the full range
+  bool IsFullRange() {
+    if (strand == 1 && starts[0] == 0 && ends[0] == -1)
+      return true;
+    return false;
+  }
+
+  // Replace by the range specified in the starts,ends section, but does not apply the strand operation.
+  // return new length
+  int Replace(char *s, int len, bool need_complement) {
+    if (IsFullRange())
+      return len;
+    int i, j, k;
+    i = 0;
+    for (k = 0; k < range_num; ++k) {
+      int start = starts[k];
+      int end = ends[k];
+      if (end == -1) end = len - 1;
+      for (j = start; j <= end; ++i, ++j)
+        s[i] = s[j];
+    }
+    s[i] = '\0';
+    len = i;
+    if (strand == -1) {
+      if (need_complement) {
+        for (i = 0; i < len; ++i) 
+          s[i] = Uint8ToChar(((uint8_t)3) ^ (CharToUint8(s[i])));
+      }
+
+      for (i = 0, j = len - 1; i < j; ++i, --j) {
+        char tmp = s[i];
+        s[i] = s[j];
+        s[j] = tmp;
+      }
+    }
+    return len;
+  }
+
+ private:
+  std::vector<int> starts;
+  std::vector<int> ends;
+  int range_num;
+  int strand;
+
+  uint8_t char_to_uint8_table_[256] = {
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+  char uint8_to_char_table_[8] = {'A', 'C', 'G', 'T',
+                                                   'N', 'N', 'N', 'N'};
+  uint8_t CharToUint8(const char c) {
+    return char_to_uint8_table_[(uint8_t)c];
+  }
+
+  char Uint8ToChar(const uint8_t i) {
+    return uint8_to_char_table_[i];
+  }
+
+};
+
+}
+
+#endif

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -31,14 +31,14 @@ class SequenceEffectiveRange {
     int j = 0;  // start, end, strand section
     char buffer[20];
     int blen = 0;
-   
+
     if (default_range) {
       starts.clear();
       ends.clear();
       strand = 1;
       default_range = false;
     }
-  
+
     for (i = 3; i <= len; ++i) {
       if (i == len || s[i] == ':') {
         buffer[blen] = '\0';
@@ -97,8 +97,14 @@ class SequenceEffectiveRange {
     for (k = 0; k < range_num; ++k) {
       int start = starts[k];
       int end = ends[k];
-      if (end == -1) end = len - 1;
-      for (j = start; j <= end; ++i, ++j) s[i] = s[j];
+
+      if (end == -1) {
+        end = len - 1;
+      }
+
+      for (j = start; j <= end; ++i, ++j) {
+        s[i] = s[j];
+      }
     }
 
     s[i] = '\0';
@@ -125,7 +131,8 @@ class SequenceEffectiveRange {
   std::vector<int> ends;
   int range_num;
   int strand;
-  bool default_range; // whether the range has been modified by new input
+  // Whether the range has been modified by new input.
+  bool default_range;
 };
 
 }  // namespace chromap

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -24,6 +24,13 @@ class SequenceEffectiveRange {
   }
 
   void FinalizeParsing() {
+    if (starts.empty() && ends.empty()) {
+      starts.push_back(0);
+      ends.push_back(-1);
+      strand = '+';
+      return;
+    }
+
     std::sort(starts.begin(), starts.end());
     std::sort(ends.begin(), ends.end());
 

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -1,14 +1,16 @@
-#ifndef SEQUENCEEFFECTIVERANGE_H_
-#define SEQUENCEEFFECTIVERANGE_H_
+#ifndef SEQUENCE_EFFECTIVE_RANGE_H_
+#define SEQUENCE_EFFECTIVE_RANGE_H_
+
+#include <stdlib.h>
 
 #include <algorithm>
 #include <vector>
 
-#include <stdlib.h>
+#include "utils.h"
 
 namespace chromap {
 
-// The class handles the custom read format indicating 
+// The class handles the custom read format indicating
 // the effective range on a sequence.
 class SequenceEffectiveRange {
  public:
@@ -21,11 +23,11 @@ class SequenceEffectiveRange {
     strand = 1;
     range_num = 1;
   }
-  
+
   // Return: false - fail to parse
   bool ParseEffectiveRange(const char *s, int len) {
     int i;
-    int j = 0; // start, end, strand section
+    int j = 0;  // start, end, strand section
     char buffer[20];
     int blen = 0;
     starts.clear();
@@ -34,28 +36,25 @@ class SequenceEffectiveRange {
     for (i = 3; i <= len; ++i) {
       if (i == len || s[i] == '/' || s[i] == ':') {
         buffer[blen] = '\0';
-        if (j == 0) 
+        if (j == 0)
           starts.push_back(atoi(buffer));
         else if (j == 1)
           ends.push_back(atoi(buffer));
-        else 
+        else
           strand = buffer[0] == '+' ? 1 : -1;
         blen = 0;
-        if (i < len && s[i] == ':')
-          ++j;
+        if (i < len && s[i] == ':') ++j;
       } else {
         buffer[blen] = s[i];
         ++blen;
       }
     }
-    if (j >= 3 || starts.size() != ends.size())
-      return false;
+    if (j >= 3 || starts.size() != ends.size()) return false;
     std::sort(starts.begin(), starts.end());
     std::sort(ends.begin(), ends.end());
     range_num = starts.size();
     if (ends[0] == -1) {
-      for (i = 0; i < range_num - 1; ++i)  
-        ends[i] = ends[i + 1];
+      for (i = 0; i < range_num - 1; ++i) ends[i] = ends[i + 1];
       ends[i] = -1;
     }
     return true;
@@ -63,30 +62,27 @@ class SequenceEffectiveRange {
 
   // Check whether the effective range is the full range
   bool IsFullRange() {
-    if (strand == 1 && starts[0] == 0 && ends[0] == -1)
-      return true;
+    if (strand == 1 && starts[0] == 0 && ends[0] == -1) return true;
     return false;
   }
 
-  // Replace by the range specified in the starts,ends section, but does not apply the strand operation.
-  // return new length
+  // Replace by the range specified in the starts,ends section, but does not
+  // apply the strand operation. return new length
   int Replace(char *s, int len, bool need_complement) {
-    if (IsFullRange())
-      return len;
+    if (IsFullRange()) return len;
     int i, j, k;
     i = 0;
     for (k = 0; k < range_num; ++k) {
       int start = starts[k];
       int end = ends[k];
       if (end == -1) end = len - 1;
-      for (j = start; j <= end; ++i, ++j)
-        s[i] = s[j];
+      for (j = start; j <= end; ++i, ++j) s[i] = s[j];
     }
     s[i] = '\0';
     len = i;
     if (strand == -1) {
       if (need_complement) {
-        for (i = 0; i < len; ++i) 
+        for (i = 0; i < len; ++i)
           s[i] = Uint8ToChar(((uint8_t)3) ^ (CharToUint8(s[i])));
       }
 
@@ -104,31 +100,8 @@ class SequenceEffectiveRange {
   std::vector<int> ends;
   int range_num;
   int strand;
-
-  uint8_t char_to_uint8_table_[256] = {
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-  char uint8_to_char_table_[8] = {'A', 'C', 'G', 'T',
-                                                   'N', 'N', 'N', 'N'};
-  uint8_t CharToUint8(const char c) {
-    return char_to_uint8_table_[(uint8_t)c];
-  }
-
-  char Uint8ToChar(const uint8_t i) {
-    return uint8_to_char_table_[i];
-  }
-
 };
 
-}
+}  // namespace chromap
 
 #endif

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -20,7 +20,7 @@ class SequenceEffectiveRange {
   void Init() {
     starts.push_back(0);
     ends.push_back(-1);
-    strand = 1;
+    strand = '+';
     default_range = true;
   }
 
@@ -34,7 +34,7 @@ class SequenceEffectiveRange {
     if (default_range) {
       starts.clear();
       ends.clear();
-      strand = 1;
+      strand = '+';
       default_range = false;
     }
 
@@ -46,7 +46,7 @@ class SequenceEffectiveRange {
         } else if (j == 1) {
           ends.push_back(atoi(buffer));
         } else {
-          strand = buffer[0] == '+' ? 1 : -1;
+          strand = buffer[0];
         }
 
         blen = 0;
@@ -77,7 +77,7 @@ class SequenceEffectiveRange {
 
   // Check whether the effective range is the full range
   bool IsFullRange() {
-    if (strand == 1 && starts[0] == 0 && ends[0] == -1) {
+    if (strand == '+' && starts[0] == 0 && ends[0] == -1) {
       return true;
     }
 
@@ -110,7 +110,7 @@ class SequenceEffectiveRange {
     s[i] = '\0';
     len = i;
 
-    if (strand == -1) {
+    if (strand == '-') {
       if (need_complement) {
         for (i = 0; i < len; ++i) {
           s[i] = Uint8ToChar(((uint8_t)3) ^ (CharToUint8(s[i])));
@@ -129,7 +129,8 @@ class SequenceEffectiveRange {
  private:
   std::vector<int> starts;
   std::vector<int> ends;
-  int strand;
+  // The barcode will be reverse-complemented after extraction if strand is '-'.
+  char strand;
   // Whether the range has been modified by new input.
   bool default_range;
 };

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -10,8 +10,8 @@
 
 namespace chromap {
 
-// The class handles the custom read format indicating
-// the effective range on a sequence.
+// The class handles the custom read format indicating the effective range on a
+// sequence.
 class SequenceEffectiveRange {
  public:
   SequenceEffectiveRange() {}
@@ -24,7 +24,7 @@ class SequenceEffectiveRange {
     range_num = 1;
   }
 
-  // Return: false - fail to parse
+  // Return false if it fails to parse the format string.
   bool ParseEffectiveRange(const char *s, int len) {
     int i;
     int j = 0;  // start, end, strand section
@@ -33,15 +33,19 @@ class SequenceEffectiveRange {
     starts.clear();
     ends.clear();
     strand = 1;
+
     for (i = 3; i <= len; ++i) {
       if (i == len || s[i] == '/' || s[i] == ':') {
         buffer[blen] = '\0';
-        if (j == 0)
+
+        if (j == 0) {
           starts.push_back(atoi(buffer));
-        else if (j == 1)
+        } else if (j == 1) {
           ends.push_back(atoi(buffer));
-        else
+        } else {
           strand = buffer[0] == '+' ? 1 : -1;
+        }
+
         blen = 0;
         if (i < len && s[i] == ':') ++j;
       } else {
@@ -49,27 +53,41 @@ class SequenceEffectiveRange {
         ++blen;
       }
     }
-    if (j >= 3 || starts.size() != ends.size()) return false;
+
+    if (j >= 3 || starts.size() != ends.size()) {
+      return false;
+    }
+
     std::sort(starts.begin(), starts.end());
     std::sort(ends.begin(), ends.end());
+
     range_num = starts.size();
     if (ends[0] == -1) {
-      for (i = 0; i < range_num - 1; ++i) ends[i] = ends[i + 1];
+      for (i = 0; i < range_num - 1; ++i) {
+        ends[i] = ends[i + 1];
+      }
       ends[i] = -1;
     }
+
     return true;
   }
 
   // Check whether the effective range is the full range
   bool IsFullRange() {
-    if (strand == 1 && starts[0] == 0 && ends[0] == -1) return true;
+    if (strand == 1 && starts[0] == 0 && ends[0] == -1) {
+      return true;
+    }
+
     return false;
   }
 
-  // Replace by the range specified in the starts,ends section, but does not
-  // apply the strand operation. return new length
+  // Replace by the range specified in the starts, ends section, but does not
+  // apply the strand operation. Return new length.
   int Replace(char *s, int len, bool need_complement) {
-    if (IsFullRange()) return len;
+    if (IsFullRange()) {
+      return len;
+    }
+
     int i, j, k;
     i = 0;
     for (k = 0; k < range_num; ++k) {
@@ -78,12 +96,15 @@ class SequenceEffectiveRange {
       if (end == -1) end = len - 1;
       for (j = start; j <= end; ++i, ++j) s[i] = s[j];
     }
+
     s[i] = '\0';
     len = i;
+
     if (strand == -1) {
       if (need_complement) {
-        for (i = 0; i < len; ++i)
+        for (i = 0; i < len; ++i) {
           s[i] = Uint8ToChar(((uint8_t)3) ^ (CharToUint8(s[i])));
+        }
       }
 
       for (i = 0, j = len - 1; i < j; ++i, --j) {

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -21,7 +21,6 @@ class SequenceEffectiveRange {
     starts.push_back(0);
     ends.push_back(-1);
     strand = 1;
-    range_num = 1;
     default_range = true;
   }
 
@@ -65,9 +64,9 @@ class SequenceEffectiveRange {
     std::sort(starts.begin(), starts.end());
     std::sort(ends.begin(), ends.end());
 
-    range_num = starts.size();
+    const int num_ranges = starts.size();
     if (ends[0] == -1) {
-      for (i = 0; i < range_num - 1; ++i) {
+      for (i = 0; i < num_ranges - 1; ++i) {
         ends[i] = ends[i + 1];
       }
       ends[i] = -1;
@@ -94,7 +93,8 @@ class SequenceEffectiveRange {
 
     int i, j, k;
     i = 0;
-    for (k = 0; k < range_num; ++k) {
+    const int num_ranges = starts.size();
+    for (k = 0; k < num_ranges; ++k) {
       int start = starts[k];
       int end = ends[k];
 
@@ -129,7 +129,6 @@ class SequenceEffectiveRange {
  private:
   std::vector<int> starts;
   std::vector<int> ends;
-  int range_num;
   int strand;
   // Whether the range has been modified by new input.
   bool default_range;

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -128,7 +128,8 @@ class SequenceEffectiveRange {
 
   std::vector<int> starts;
   std::vector<int> ends;
-  // The barcode will be reverse-complemented after extraction if strand is '-'.
+  // Strand is either '+' or '-'. The barcode will be reverse-complemented after
+  // extraction if strand is '-'.
   char strand;
   // Whether the range has been modified by new input.
   bool default_range;

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -22,6 +22,7 @@ class SequenceEffectiveRange {
     ends.push_back(-1);
     strand = 1;
     range_num = 1;
+    default_range = true;
   }
 
   // Return false if it fails to parse the format string.
@@ -30,14 +31,17 @@ class SequenceEffectiveRange {
     int j = 0;  // start, end, strand section
     char buffer[20];
     int blen = 0;
-    starts.clear();
-    ends.clear();
-    strand = 1;
-
+   
+    if (default_range) {
+      starts.clear();
+      ends.clear();
+      strand = 1;
+      default_range = false;
+    }
+  
     for (i = 3; i <= len; ++i) {
-      if (i == len || s[i] == '/' || s[i] == ':') {
+      if (i == len || s[i] == ':') {
         buffer[blen] = '\0';
-
         if (j == 0) {
           starts.push_back(atoi(buffer));
         } else if (j == 1) {
@@ -121,6 +125,7 @@ class SequenceEffectiveRange {
   std::vector<int> ends;
   int range_num;
   int strand;
+  bool default_range; // whether the range has been modified by new input
 };
 
 }  // namespace chromap

--- a/src/utils.h
+++ b/src/utils.h
@@ -86,6 +86,29 @@ inline static void ExitWithMessage(const std::string &message) {
   exit(-1);
 }
 
+static constexpr uint8_t char_to_uint8_table_[256] = {
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+static constexpr char uint8_to_char_table_[8] = {'A', 'C', 'G', 'T',
+                                                 'N', 'N', 'N', 'N'};
+
+inline static uint8_t CharToUint8(const char c) {
+  return char_to_uint8_table_[(uint8_t)c];
+}
+
+inline static char Uint8ToChar(const uint8_t i) {
+  return uint8_to_char_table_[i];
+}
+
 }  // namespace chromap
 
 #endif  // UTILS_H_


### PR DESCRIPTION
- Parse "/" symbol in the --read-format option: e.g: "--read-format bc:0/8:3/-1" would specify using barcode segments from [0,3] and [8, read_end].
- Could resolve #42 