### PR TITLE
Support globbing in read file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ But note that the the processing of SAM files is not fully optimized and can be 
 ```sh
 chromap -x index -r ref.fa -1 query1.fq,query2.fq,query3.fq --SAM -o alignment.sam
 ```
+Chromap also supports wildcards in the read file names and will find all matched read files. To use this function, the read file names ***must*** be put in quotation marks:
+
+```sh
+chromap -x index -r ref.fa -1 "query*.fq" --SAM -o alignment.sam
+```
 Chromap works with gzip'd FASTA and FASTQ formats as input. You don't need to convert between FASTA and FASTQ or decompress gzip'd files first. 
 
 ***Importantly***, it should be noted that once you build the index, indexing parameters such as **-k**, **-w** and **--min-frag-length** can't be changed during mapping. If you are running Chromap for different data types, you will probably need to keep multiple indexes generated with different parameters.

--- a/chromap.1
+++ b/chromap.1
@@ -1,4 +1,4 @@
-.TH chromap 1 "20 May 2023" "chromap-0.2.5 (r473)" "Bioinformatics tools"
+.TH chromap 1 "29 Aug 2023" "chromap-0.2.5 (r478)" "Bioinformatics tools"
 .SH NAME
 .PP
 chromap - fast alignment and preprocessing of chromatin profiles

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -29,7 +29,7 @@
 #include "temp_mapping.h"
 #include "utils.h"
 
-#define CHROMAP_VERSION "0.2.5-r473"
+#define CHROMAP_VERSION "0.2.5-r478"
 
 namespace chromap {
 

--- a/src/chromap_driver.cc
+++ b/src/chromap_driver.cc
@@ -20,24 +20,16 @@ void AddIndexingOptions(cxxopts::Options &options) {
       "w,window", "Window size [7]", cxxopts::value<int>(), "INT");
 }
 
-}  // namespace
-
-void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
-  cxxopts::Options options(
-      "chromap", "Fast alignment and preprocessing of chromatin profiles");
-
-  AddIndexingOptions(options);
-
-  options.set_width(120).add_options("Mapping")
-      //("m,map", "Map reads")
-      ("preset",
-       "Preset parameters for mapping reads (always applied before other "
-       "options) []\natac: mapping ATAC-seq/scATAC-seq reads\nchip: mapping "
-       "ChIP-seq reads\nhic: mapping Hi-C reads",
-       cxxopts::value<std::string>(),
-       "STR")("split-alignment", "Allow split alignments")(
-          "e,error-threshold", "Max # errors allowed to map a read [8]",
-          cxxopts::value<int>(), "INT")
+void AddMappingOptions(cxxopts::Options &options) {
+  options.set_width(120).add_options("Mapping")(
+      "preset",
+      "Preset parameters for mapping reads (always applied before other "
+      "options) []\natac: mapping ATAC-seq/scATAC-seq reads\nchip: mapping "
+      "ChIP-seq reads\nhic: mapping Hi-C reads",
+      cxxopts::value<std::string>(),
+      "STR")("split-alignment", "Allow split alignments")(
+      "e,error-threshold", "Max # errors allowed to map a read [8]",
+      cxxopts::value<int>(), "INT")
       //("A,match-score", "Match score [1]", cxxopts::value<int>(), "INT")
       //("B,mismatch-penalty", "Mismatch penalty [4]", cxxopts::value<int>(),
       //"INT")
@@ -83,16 +75,9 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
                  cxxopts::value<double>(),
                  "FLT")("t,num-threads", "# threads for mapping [1]",
                         cxxopts::value<int>(), "INT");
-  // options.add_options("Peak")
-  //  ("cell-by-bin", "Generate cell-by-bin matrix")
-  //  ("bin-size", "Bin size to generate cell-by-bin matrix [5000]",
-  //  cxxopts::value<int>(), "INT")
-  //  ("depth-cutoff", "Depth cutoff for peak calling [3]",
-  //  cxxopts::value<int>(), "INT")
-  //  ("peak-min-length", "Min length of peaks to report [30]",
-  //  cxxopts::value<int>(), "INT")
-  //  ("peak-merge-max-length", "Peaks within this length will be merged [30]",
-  //  cxxopts::value<int>(), "INT");
+}
+
+void AddInputOptions(cxxopts::Options &options) {
   options.add_options("Input")("r,ref", "Reference file",
                                cxxopts::value<std::string>(), "FILE")(
       "x,index", "Index file", cxxopts::value<std::string>(), "FILE")(
@@ -108,6 +93,9 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
               "Format for read files and barcode files  [\"r1:0:-1,bc:0:-1\" "
               "as 10x Genomics single-end format]",
               cxxopts::value<std::string>(), "STR");
+}
+
+void AddOutputOptions(cxxopts::Options &options) {
   options.add_options("Output")("o,output", "Output file",
                                 cxxopts::value<std::string>(), "FILE")
       //("p,matrix-output-prefix", "Prefix of matrix output files",
@@ -134,7 +122,9 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
           "Summarize the mapping statistics at bulk or barcode level",
           cxxopts::value<std::string>(), "FILE");
   //("PAF", "Output mappings in PAF format (only for test)");
-  options.add_options()("v,version", "Print version")("h,help", "Print help");
+}
+
+void AddDevelopmentOptions(cxxopts::Options &options) {
   options.add_options("Development options")("A,match-score", "Match score [1]",
                                              cxxopts::value<int>(), "INT")(
       "B,mismatch-penalty", "Mismatch penalty [4]", cxxopts::value<int>(),
@@ -157,6 +147,38 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
       "PAF", "Output mappings in PAF format (only for test)")(
       "skip-barcode-check",
       "Do not check whether too few barcodes are in the whitelist");
+}
+
+void AddPeakOptions(cxxopts::Options &options) {
+  options.add_options("Peak")("cell-by-bin", "Generate cell-by-bin matrix")(
+      "bin-size", "Bin size to generate cell-by-bin matrix [5000]",
+      cxxopts::value<int>(),
+      "INT")("depth-cutoff", "Depth cutoff for peak calling [3]",
+             cxxopts::value<int>(),
+             "INT")("peak-min-length", "Min length of peaks to report [30]",
+                    cxxopts::value<int>(), "INT")(
+      "peak-merge-max-length", "Peaks within this length will be merged [30]",
+      cxxopts::value<int>(), "INT");
+}
+
+}  // namespace
+
+void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
+  cxxopts::Options options(
+      "chromap", "Fast alignment and preprocessing of chromatin profiles");
+
+  options.add_options()("v,version", "Print version")("h,help", "Print help");
+
+  AddIndexingOptions(options);
+  AddMappingOptions(options);
+
+  // We don't support peak options for now.
+  // AddPeakOptions(options);
+
+  AddInputOptions(options);
+  AddOutputOptions(options);
+
+  AddDevelopmentOptions(options);
 
   auto result = options.parse(argc, argv);
   if (result.count("h")) {

--- a/src/chromap_driver.cc
+++ b/src/chromap_driver.cc
@@ -9,16 +9,25 @@
 #include "cxxopts.hpp"
 
 namespace chromap {
+namespace {
 
-void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
-  cxxopts::Options options(
-      "chromap", "Fast alignment and preprocessing of chromatin profiles");
+void AddIndexingOptions(cxxopts::Options &options) {
   options.add_options("Indexing")("i,build-index", "Build index")(
       "min-frag-length",
       "Min fragment length for choosing k and w automatically [30]",
       cxxopts::value<int>(),
       "INT")("k,kmer", "Kmer length [17]", cxxopts::value<int>(), "INT")(
       "w,window", "Window size [7]", cxxopts::value<int>(), "INT");
+}
+
+}  // namespace
+
+void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
+  cxxopts::Options options(
+      "chromap", "Fast alignment and preprocessing of chromatin profiles");
+
+  AddIndexingOptions(options);
+
   options.set_width(120).add_options("Mapping")
       //("m,map", "Map reads")
       ("preset",
@@ -120,9 +129,10 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
           cxxopts::value<std::string>(),
           "FILE")("barcode-translate",
                   "Convert barcode to the specified sequences during output",
-                  cxxopts::value<std::string>(), "FILE")
-            ("summary", "Summarize the mapping statistics at bulk or barcode level",
-             cxxopts::value<std::string>(), "FILE");
+                  cxxopts::value<std::string>(), "FILE")(
+          "summary",
+          "Summarize the mapping statistics at bulk or barcode level",
+          cxxopts::value<std::string>(), "FILE");
   //("PAF", "Output mappings in PAF format (only for test)");
   options.add_options()("v,version", "Print version")("h,help", "Print help");
   options.add_options("Development options")("A,match-score", "Match score [1]",
@@ -430,10 +440,10 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
       mapping_parameters.barcode_translate_table_file_path =
           result["barcode-translate"].as<std::string>();
     }
-    
+
     if (result.count("summary")) {
-      mapping_parameters.summary_metadata_file_path = 
-        result["summary"].as<std::string>();
+      mapping_parameters.summary_metadata_file_path =
+          result["summary"].as<std::string>();
     }
 
     if (result.count("skip-barcode-check")) {


### PR DESCRIPTION
1. Now Chromap can support wildcards in read file names and find all matched read files. But the read file names must be in quotation marks in the command line to avoid globbing there so that Chromap can do the globbing.
2. Refactor the code.