### PR TITLE
Move li_dev4's content to li_dev5, including no-sorting read-format, …

### DIFF
--- a/src/candidate.h
+++ b/src/candidate.h
@@ -1,6 +1,8 @@
 #ifndef CANDIDATE_H_
 #define CANDIDATE_H_
 
+#include <stdint.h>
+
 namespace chromap {
 
 struct Candidate {

--- a/src/candidate_position_generating_config.h
+++ b/src/candidate_position_generating_config.h
@@ -1,6 +1,8 @@
 #ifndef CANDIDATE_POSITION_GENERATING_CONFIG_H_
 #define CANDIDATE_POSITION_GENERATING_CONFIG_H_
 
+#include <stdint.h>
+
 namespace chromap {
 
 // This class holds the parameters to generate candidate position. Using the

--- a/src/index_utils.h
+++ b/src/index_utils.h
@@ -1,6 +1,8 @@
 #ifndef INDEX_UTILS_H_
 #define INDEX_UTILS_H_
 
+#include <stdint.h>
+
 #include "khash.h"
 
 // Note that the max kmer size is 28 and its hash value is always saved in the

--- a/src/mapping_in_memory.h
+++ b/src/mapping_in_memory.h
@@ -83,7 +83,7 @@ struct PairedEndMappingInMemory {
     return mapping_in_memory2.GetFragmentStartPosition();
   }
 
-  inline uint16_t GetFragmentLength() const {
+  inline int GetFragmentLength() const {
     if (mapping_in_memory1.strand == kPositive) {
       return mapping_in_memory2.ref_end_position -
              mapping_in_memory1.ref_start_position + 1;

--- a/src/sequence_effective_range.h
+++ b/src/sequence_effective_range.h
@@ -31,13 +31,13 @@ class SequenceEffectiveRange {
       return;
     }
 
-    std::sort(starts.begin(), starts.end());
+    /*std::sort(starts.begin(), starts.end());
     std::sort(ends.begin(), ends.end());
 
     if (ends[0] == -1) {
       ends.erase(ends.begin());
       ends.push_back(-1);
-    }
+    }*/
   }
 
   // Return false if it fails to parse the format string.


### PR DESCRIPTION
…and overflow of fragment length

- Addresses issues #139 and #135 .