### PR TITLE
Fix a bug in the summary file for SAM format output. Add the duplicate count in the bulk data BED output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The start and end are inclusive and -1 means the end of the read. User may use m
 
 The output file formats for bulk and single-cell data are different except for the first three columns. For bulk data, the columns are
 
-    chrom chrom_start chrom_end N mapq strand
+    chrom chrom_start chrom_end N mapq strand duplicate_count
 For single-cell data, the columns are 
     
     chrom chrom_start chrom_end barcode duplicate_count

--- a/chromap.1
+++ b/chromap.1
@@ -1,4 +1,4 @@
-.TH chromap 1 "25 Jan 2024" "chromap-0.2.6 (r489)" "Bioinformatics tools"
+.TH chromap 1 "25 Jan 2024" "chromap-0.2.6 (r490)" "Bioinformatics tools"
 .SH NAME
 .PP
 chromap - fast alignment and preprocessing of chromatin profiles

--- a/chromap.1
+++ b/chromap.1
@@ -1,4 +1,4 @@
-.TH chromap 1 "29 Aug 2023" "chromap-0.2.5 (r478)" "Bioinformatics tools"
+.TH chromap 1 "25 Jan 2024" "chromap-0.2.6 (r489)" "Bioinformatics tools"
 .SH NAME
 .PP
 chromap - fast alignment and preprocessing of chromatin profiles

--- a/src/bed_mapping.h
+++ b/src/bed_mapping.h
@@ -68,11 +68,11 @@ class MappingWithoutBarcode : public Mapping {
   uint16_t fragment_length_;
   // uint8_t mapq;
   uint8_t mapq_ : 6, direction_ : 1, is_unique_ : 1;
-  uint8_t num_dups_;
+  uint16_t num_dups_; // Need higher limit in bulk setting
 
   MappingWithoutBarcode() : num_dups_(0) {}
   MappingWithoutBarcode(uint32_t read_id, uint32_t fragment_start_position,
-                        uint16_t fragment_length, uint8_t mapq,
+                        uint16_t fragment_length, uint16_t mapq,
                         uint8_t direction, uint8_t is_unique, uint8_t num_dups)
       : read_id_(read_id),
         fragment_start_position_(fragment_start_position),
@@ -192,7 +192,7 @@ class PairedEndMappingWithoutBarcode : public Mapping {
                                  uint32_t fragment_start_position,
                                  uint16_t fragment_length, uint8_t mapq,
                                  uint8_t direction, uint8_t is_unique,
-                                 uint8_t num_dups,
+                                 uint16_t num_dups,
                                  uint16_t positive_alignment_length,
                                  uint16_t negative_alignment_length)
       : read_id_(read_id),

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -29,7 +29,7 @@
 #include "temp_mapping.h"
 #include "utils.h"
 
-#define CHROMAP_VERSION "0.2.5-r478"
+#define CHROMAP_VERSION "0.2.6-r489"
 
 namespace chromap {
 

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -29,7 +29,7 @@
 #include "temp_mapping.h"
 #include "utils.h"
 
-#define CHROMAP_VERSION "0.2.6-r489"
+#define CHROMAP_VERSION "0.2.6-r490"
 
 namespace chromap {
 

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -1119,6 +1119,8 @@ void Chromap::MapPairedEndReads() {
     //  }
     //}
   }
+  if (mapping_parameters_.mapping_output_format == MAPPINGFORMAT_SAM)
+    mapping_writer.AdjustSummaryPairedEndOverCount() ;
   mapping_writer.OutputSummaryMetadata();
 
   reference.FinalizeLoading();

--- a/src/mapping_writer.cc
+++ b/src/mapping_writer.cc
@@ -50,7 +50,7 @@ void MappingWriter<MappingWithoutBarcode>::AppendMapping(
                               std::to_string(mapping.GetStartPosition()) +
                               "\t" + std::to_string(mapping_end_position) +
                               "\tN\t" + std::to_string(mapping.mapq_) + "\t" +
-                              strand + "\n");
+                              strand + "\t" + std::to_string(mapping.num_dups_) + "\n");
   } else {
     std::string strand = mapping.IsPositiveStrand() ? "+" : "-";
     const char *reference_sequence_name = reference.GetSequenceNameAt(rid);
@@ -59,7 +59,7 @@ void MappingWriter<MappingWithoutBarcode>::AppendMapping(
                               std::to_string(mapping.GetStartPosition()) +
                               "\t" + std::to_string(mapping_end_position) +
                               "\tN\t" + std::to_string(mapping.mapq_) + "\t" +
-                              strand + "\n");
+                              strand + "\t" + std::to_string(mapping.num_dups_) + "\n");
   }
 }
 
@@ -80,7 +80,7 @@ void MappingWriter<PairedEndMappingWithoutBarcode>::AppendMapping(
                               std::to_string(mapping.GetStartPosition()) +
                               "\t" + std::to_string(mapping_end_position) +
                               "\tN\t" + std::to_string(mapping.mapq_) + "\t" +
-                              strand + "\n");
+                              strand + "\t" + std::to_string(mapping.num_dups_) + "\n");
   } else {
     bool positive_strand = mapping.IsPositiveStrand();
     uint32_t positive_read_end =
@@ -99,7 +99,8 @@ void MappingWriter<PairedEndMappingWithoutBarcode>::AppendMapping(
           std::string(reference_sequence_name) + "\t" +
           std::to_string(negative_read_start) + "\t" +
           std::to_string(negative_read_end) + "\tN\t" +
-          std::to_string(mapping.mapq_) + "\t-\n");
+          std::to_string(mapping.mapq_) + "\t-\t" + 
+          std::to_string(mapping.num_dups_) + "\n");
     } else {
       this->AppendMappingOutput(
           std::string(reference_sequence_name) + "\t" +
@@ -109,7 +110,8 @@ void MappingWriter<PairedEndMappingWithoutBarcode>::AppendMapping(
           std::string(reference_sequence_name) + "\t" +
           std::to_string(mapping.fragment_start_position_) + "\t" +
           std::to_string(positive_read_end) + "\tN\t" +
-          std::to_string(mapping.mapq_) + "\t+\n");
+          std::to_string(mapping.mapq_) + "\t+\t" +
+          std::to_string(mapping.num_dups_) + "\n");
     }
   }
 }

--- a/src/mapping_writer.h
+++ b/src/mapping_writer.h
@@ -70,6 +70,7 @@ class MappingWriter {
 
   void OutputSummaryMetadata();
   void UpdateSummaryMetadata(uint64_t barcode, int type, int change);
+  void AdjustSummaryPairedEndOverCount();
 
  protected:
   void AppendMapping(uint32_t rid, const SequenceBatch &reference,
@@ -438,7 +439,9 @@ void MappingWriter<MappingRecord>::OutputMappings(
 template <typename MappingRecord>
 void MappingWriter<MappingRecord>::OutputSummaryMetadata() {
   if (!mapping_parameters_.summary_metadata_file_path.empty())
+  {
     summary_metadata_.Output(mapping_parameters_.summary_metadata_file_path.c_str());
+  }
 }
 
 template <typename MappingRecord>
@@ -447,6 +450,15 @@ template <typename MappingRecord>
   if (!mapping_parameters_.summary_metadata_file_path.empty())
     summary_metadata_.UpdateCount(barcode, type, change);
 }
+
+template <typename MappingRecord>
+  void MappingWriter<MappingRecord>::AdjustSummaryPairedEndOverCount()
+{
+  if (!mapping_parameters_.summary_metadata_file_path.empty()
+      && mapping_parameters_.mapping_output_format == MAPPINGFORMAT_SAM)
+      summary_metadata_.AdjustPairedEndOverCount() ; 
+}
+
 
 // Specialization for BED format.
 template <>

--- a/src/summary_metadata.h
+++ b/src/summary_metadata.h
@@ -75,6 +75,17 @@ class SummaryMetadata {
     barcode_length_ = l;
   }
 
+  // In SAM format for paired-end data, some count will be counted twice
+  void AdjustPairedEndOverCount() {
+    khiter_t k;
+    for (k = kh_begin(barcode_metadata_); k != kh_end(barcode_metadata_); ++k)
+      if (kh_exist(barcode_metadata_, k)) {
+        kh_value(barcode_metadata_, k).counts[SUMMARY_METADATA_DUP] /= 2 ;
+        kh_value(barcode_metadata_, k).counts[SUMMARY_METADATA_LOWMAPQ] /= 2 ;
+        kh_value(barcode_metadata_, k).counts[SUMMARY_METADATA_MAPPED] /= 2 ;
+      } 
+  }
+
  private:
   khash_t(k64_barcode_metadata) *barcode_metadata_;    
   int barcode_length_;

--- a/src/temp_mapping.h
+++ b/src/temp_mapping.h
@@ -39,6 +39,9 @@ struct TempMappingFileHandle {
 
   inline void InitializeTempMappingLoading(uint32_t temp_mapping_block_size) {
     file = fopen(file_path.c_str(), "rb");
+    if (file == NULL) {
+      std::cerr << "Temporary file " << file_path << " is missing.\n" ;
+    }
     assert(file != NULL);
     num_mappings = 0;
     block_size = temp_mapping_block_size;


### PR DESCRIPTION
- Fix a bug in the summary file for SAM format output.  #143 
- Add the duplicate count in the bulk data BED output. #145 
- Print the temporary file name if it is not found. For future debugging of #142 
- Update the version number to v0.2.6.