### PR TITLE
chromap-qc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd chromap && make
     - [Map ChIP-seq short reads](#map-chip)
     - [Map ATAC-seq/scATAC-seq short reads](#map-atac)
     - [Map Hi-C short reads](#map-hic)
-  - [Summarizing mapping statistcs/quality control](#atacseq-qc)
+  - [Summarizing mapping statistics/quality control](#atacseq-qc)
     - [Summary File](#summaryfile)
     - [Estimating FRiP](#estfrip)
     - [Features to assist in doublet detection](#doublet)
@@ -128,7 +128,7 @@ chromap --preset hic -x index -r ref.fa -1 read1.fa -2 read2.fa -o aln.pairs    
 ```
 Chromap will perform split alignment (**--split-alignment**) on Hi-C reads and output mappings in [pairs][pairs] format (**--pairs**), which is used in [4DN Hi-C data processing pipeline][4DN]. Some Hi-C data analysis pipelines may require the reads are sorted in specific chromosome order other than the one in the index. Therefore, Chromap provides the option **--chr-order** to specify the alignment order, and **--pairs-natural-chr-order** for flipping the pair in the pairs format. 
 
-### <a name="atacseq-qc"></a>Summarizing mapping statistcs/quality control
+### <a name="atacseq-qc"></a>Summarizing mapping statistics/quality control
 
 Chromap allows you to summarize the dataset's mapping statistics as well as quality metrics at either a *bulk* or *single cell* level. To enable this feature, users can specify a file path using this option, **--summary [FILE]**, where a csv file will be saved.
 

--- a/src/candidate.h
+++ b/src/candidate.h
@@ -18,6 +18,8 @@ struct Candidate {
 
   inline uint32_t GetReferenceSequencePosition() const { return position; }
 
+  inline uint8_t GetCount() { return count; }
+
   inline bool operator<(const Candidate &c) const {
     if (count > c.count) {
       return true;

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -375,7 +375,6 @@ void Chromap::MapSingleEndReads() {
           mm_to_candidates_cache.GetUpdateThreshold(num_loaded_reads,
                                                     num_reads_, 
                                                     false,
-                                                    false,
                                                     0.01);
           // int grain_size = 10000;
 //#pragma omp taskloop grainsize(grain_size) //num_tasks(num_threads_* 50)
@@ -673,7 +672,6 @@ void Chromap::MapPairedEndReads() {
 
   // Check cache-related parameters
   std::cerr << "Cache Size: " << mapping_parameters_.cache_size << std::endl;
-  std::cerr << "Use All Reads for Cache: " << mapping_parameters_.use_all_reads << std::endl;
   std::cerr << "Cache Update Param: " << mapping_parameters_.cache_update_param << std::endl;
   
   std::vector<uint64_t> seeds_for_batch(500000, 0);
@@ -865,7 +863,6 @@ void Chromap::MapPairedEndReads() {
           mm_to_candidates_cache.GetUpdateThreshold(num_loaded_pairs,
                                                     num_reads_, 
                                                     true,
-                                                    mapping_parameters_.use_all_reads,
                                                     mapping_parameters_.cache_update_param
                                                     );
           int cache_hits_for_batch = 0;

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -34,7 +34,7 @@
 #include "temp_mapping.h"
 #include "utils.h"
 
-#define CHROMAP_VERSION "0.2.7-r494"
+#define CHROMAP_VERSION "0.3.0-r508"
 
 namespace chromap {
 

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -49,9 +49,7 @@ public:
      */
     K_MinHash(size_t k, size_t range) : k_(k), range_(range) {}
 
-    // K_MinHash(): k_(250), range_(4000003) {}
-
-    void add(size_t num) {
+    inline void add(size_t num) {
       /* If num is not present in queue, we will add it */
         if (unique_slots_.find(num) == unique_slots_.end()) {
             unique_slots_.insert(num);
@@ -64,11 +62,10 @@ public:
         }
     }
 
-    size_t compute_cardinality() {
+    inline size_t compute_cardinality() {
       /* Use k-MinHash estimator to return estimated cardinality */
-      size_t k_for_calc = k_;
-      if (pq_.size() < k_) {k_for_calc = pq_.size();}
-      size_t cardinality = (k_for_calc * range_)/pq_.top() - 1;
+      if (pq_.size() < k_) {return 0;}
+      size_t cardinality = (k_ * range_)/pq_.top() - 1;
       return cardinality;
     }
 

--- a/src/chromap.h
+++ b/src/chromap.h
@@ -1366,6 +1366,7 @@ void Chromap::MapPairedEndReads() {
 
   mapping_writer.OutputSummaryMetadata(frip_est_params, output_num_cache_slots_info);
   reference.FinalizeLoading();
+  if (mapping_parameters_.debug_cache) {mm_to_candidates_cache.PrintStats();}
   
   std::cerr << "Total time: " << GetRealTime() - real_start_time << "s.\n";
 }

--- a/src/chromap_driver.cc
+++ b/src/chromap_driver.cc
@@ -77,13 +77,9 @@ void AddMappingOptions(cxxopts::Options &options) {
                  cxxopts::value<double>(),
                  "FLT")("t,num-threads", "# threads for mapping [1]",
                         cxxopts::value<int>(), "INT")
-      ("cache-size", "number of cache entries [4000003]", cxxopts::value<int>(), "INT")
-      ("cache-update-param", "value used to control number of reads sampled [0.01]", cxxopts::value<double>(), "FLT")
-      ("debug-cache", "verbose output for debugging cache used in chromap")
       ("frip-est-params", "coefficients used for frip est calculation, separated by semi-colons",
       cxxopts::value<std::string>(), "STR")
-      ("turn-off-num-uniq-cache-slots", "turn off the output of number of cache slots in summary file")
-      ("k-for-minhash", "number of values stored in each MinHash sketch [250]", cxxopts::value<int>(), "INT");
+      ("turn-off-num-uniq-cache-slots", "turn off the output of number of cache slots in summary file");
 }
 
 void AddInputOptions(cxxopts::Options &options) {
@@ -155,7 +151,11 @@ void AddDevelopmentOptions(cxxopts::Options &options) {
       "INT")("allocate-multi-mappings", "Allocate multi-mappings")(
       "PAF", "Output mappings in PAF format (only for test)")(
       "skip-barcode-check",
-      "Do not check whether too few barcodes are in the whitelist");
+      "Do not check whether too few barcodes are in the whitelist")
+      ("cache-size", "number of cache entries [4000003]", cxxopts::value<int>(), "INT")
+      ("cache-update-param", "value used to control number of reads sampled [0.01]", cxxopts::value<double>(), "FLT")
+      ("debug-cache", "verbose output for debugging cache used in chromap")
+      ("k-for-minhash", "number of values stored in each MinHash sketch [250]", cxxopts::value<int>(), "INT");
 }
 
 void AddPeakOptions(cxxopts::Options &options) {

--- a/src/chromap_driver.cc
+++ b/src/chromap_driver.cc
@@ -79,10 +79,12 @@ void AddMappingOptions(cxxopts::Options &options) {
                         cxxopts::value<int>(), "INT")
       ("cache-size", "number of cache entries [4000003]", cxxopts::value<int>(), "INT")
       ("cache-update-param", "value used to control number of reads sampled [0.01]", cxxopts::value<double>(), "FLT")
-      ("use-all-reads", "use all reads for cache")
+      ("use-all-reads", "use all reads for cache (it will slow down execution)")
       ("debug-cache", "verbose output for debugging cache used in chromap")
-      ("frip-est-params", "coefficients used for chromap score calculation separated by semi-colons",
-      cxxopts::value<std::string>(), "STR");
+      ("frip-est-params", "coefficients used for frip est calculation, separated by semi-colons",
+      cxxopts::value<std::string>(), "STR")
+      ("turn-off-num-uniq-cache-slots", "turn off the output of number of cache slots in summary file")
+      ("k-for-minhash", "number of values stored in each MinHash sketch [250]", cxxopts::value<int>(), "INT");
 }
 
 void AddInputOptions(cxxopts::Options &options) {
@@ -354,7 +356,15 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
   if (result.count("frip-est-params")) {
     mapping_parameters.frip_est_params = result["frip-est-params"].as<std::string>();
   }
-
+  if (result.count("turn-off-num-uniq-cache-slots")) {
+    mapping_parameters.output_num_uniq_cache_slots = false;
+  } 
+  if (result.count("k-for-minhash")) {
+    mapping_parameters.k_for_minhash = result["k-for-minhash"].as<int>();
+    if (mapping_parameters.k_for_minhash < 1 || mapping_parameters.k_for_minhash >= 2000) {
+      chromap::ExitWithMessage("Invalid paramter for size of MinHash sketch (--k-for-minhash)");
+    }
+  }
 
 
   if (result.count("min-read-length")) {

--- a/src/chromap_driver.cc
+++ b/src/chromap_driver.cc
@@ -76,7 +76,11 @@ void AddMappingOptions(cxxopts::Options &options) {
                  "Min probability to correct a barcode [0.9]",
                  cxxopts::value<double>(),
                  "FLT")("t,num-threads", "# threads for mapping [1]",
-                        cxxopts::value<int>(), "INT");
+                        cxxopts::value<int>(), "INT")
+      ("cache-size", "number of cache entries [4000003]", cxxopts::value<int>(), "INT")
+      ("cache-update-param", "value used to control number of reads sampled [0.01]", cxxopts::value<double>(), "FLT")
+      ("use-all-reads", "use all reads for cache")
+      ("debug-cache", "verbose output for debugging cache used in chromap");
 }
 
 void AddInputOptions(cxxopts::Options &options) {
@@ -324,6 +328,30 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
   if (result.count("t")) {
     mapping_parameters.num_threads = result["num-threads"].as<int>();
   }
+
+
+  // check cache-related parameters
+  if (result.count("cache-update-param")) {
+    mapping_parameters.cache_update_param = result["cache-update-param"].as<double>();
+    if (mapping_parameters.cache_update_param < 0.0 || mapping_parameters.cache_update_param > 1.0){
+      chromap::ExitWithMessage("cache update param is not approriate, must be in this range (0, 1]");
+    }
+  } 
+  if (result.count("cache-size")) {
+    mapping_parameters.cache_size = result["cache-size"].as<int>();
+    if (mapping_parameters.cache_size < 2000000 || mapping_parameters.cache_size > 15000000) {
+        chromap::ExitWithMessage("cache size is not in appropriate range\n");
+    }
+  }
+  if (result.count("use-all-reads")) {
+    mapping_parameters.use_all_reads = true;
+  }
+  if (result.count("debug-cache")) {
+    mapping_parameters.debug_cache = true;
+  }
+
+
+
   if (result.count("min-read-length")) {
     mapping_parameters.min_read_length = result["min-read-length"].as<int>();
   }

--- a/src/chromap_driver.cc
+++ b/src/chromap_driver.cc
@@ -79,7 +79,6 @@ void AddMappingOptions(cxxopts::Options &options) {
                         cxxopts::value<int>(), "INT")
       ("cache-size", "number of cache entries [4000003]", cxxopts::value<int>(), "INT")
       ("cache-update-param", "value used to control number of reads sampled [0.01]", cxxopts::value<double>(), "FLT")
-      ("use-all-reads", "use all reads for cache (it will slow down execution)")
       ("debug-cache", "verbose output for debugging cache used in chromap")
       ("frip-est-params", "coefficients used for frip est calculation, separated by semi-colons",
       cxxopts::value<std::string>(), "STR")
@@ -346,9 +345,6 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
     if (mapping_parameters.cache_size < 2000000 || mapping_parameters.cache_size > 15000000) {
         chromap::ExitWithMessage("cache size is not in appropriate range\n");
     }
-  }
-  if (result.count("use-all-reads")) {
-    mapping_parameters.use_all_reads = true;
   }
   if (result.count("debug-cache")) {
     mapping_parameters.debug_cache = true;

--- a/src/chromap_driver.cc
+++ b/src/chromap_driver.cc
@@ -80,7 +80,9 @@ void AddMappingOptions(cxxopts::Options &options) {
       ("cache-size", "number of cache entries [4000003]", cxxopts::value<int>(), "INT")
       ("cache-update-param", "value used to control number of reads sampled [0.01]", cxxopts::value<double>(), "FLT")
       ("use-all-reads", "use all reads for cache")
-      ("debug-cache", "verbose output for debugging cache used in chromap");
+      ("debug-cache", "verbose output for debugging cache used in chromap")
+      ("frip-est-params", "coefficients used for chromap score calculation separated by semi-colons",
+      cxxopts::value<std::string>(), "STR");
 }
 
 void AddInputOptions(cxxopts::Options &options) {
@@ -348,6 +350,9 @@ void ChromapDriver::ParseArgsAndRun(int argc, char *argv[]) {
   }
   if (result.count("debug-cache")) {
     mapping_parameters.debug_cache = true;
+  }
+  if (result.count("frip-est-params")) {
+    mapping_parameters.frip_est_params = result["frip-est-params"].as<std::string>();
   }
 
 

--- a/src/mapping_parameters.h
+++ b/src/mapping_parameters.h
@@ -26,7 +26,6 @@ struct MappingParameters {
 
   double cache_update_param = 0.01;
   int cache_size = 4000003;
-  bool use_all_reads = false;
   bool debug_cache = false;
   std::string frip_est_params = "0.2809;0.8921;7.490e-06;-1.893e-05;-2.178e-05";
   bool output_num_uniq_cache_slots = true;

--- a/src/mapping_parameters.h
+++ b/src/mapping_parameters.h
@@ -23,6 +23,12 @@ struct MappingParameters {
   std::vector<int> gap_extension_penalties = {1, 1};
   int min_num_seeds_required_for_mapping = 2;
   std::vector<int> max_seed_frequencies = {500, 1000};
+
+  double cache_update_param = 0.01;
+  int cache_size = 4000003;
+  bool use_all_reads = false;
+  bool debug_cache = false;
+
   // Read with # best mappings greater than it will have this number of best
   // mappings reported.
   int max_num_best_mappings = 1;

--- a/src/mapping_parameters.h
+++ b/src/mapping_parameters.h
@@ -27,7 +27,7 @@ struct MappingParameters {
   double cache_update_param = 0.01;
   int cache_size = 4000003;
   bool debug_cache = false;
-  std::string frip_est_params = "0.2771;0.9153;6.0499e-06;-6.1495e-05;-5.8978e-05";
+  std::string frip_est_params = "-1.0996;4.2391;3.0164e-05;-2.1087e-04;-5.5825e-05";
   bool output_num_uniq_cache_slots = true;
   int k_for_minhash = 250;
 

--- a/src/mapping_parameters.h
+++ b/src/mapping_parameters.h
@@ -27,7 +27,7 @@ struct MappingParameters {
   double cache_update_param = 0.01;
   int cache_size = 4000003;
   bool debug_cache = false;
-  std::string frip_est_params = "0.2809;0.8921;7.490e-06;-1.893e-05;-2.178e-05";
+  std::string frip_est_params = "0.2771;0.9153;6.0499e-06;-6.1495e-05;-5.8978e-05";
   bool output_num_uniq_cache_slots = true;
   int k_for_minhash = 250;
 

--- a/src/mapping_parameters.h
+++ b/src/mapping_parameters.h
@@ -28,6 +28,7 @@ struct MappingParameters {
   int cache_size = 4000003;
   bool use_all_reads = false;
   bool debug_cache = false;
+  std::string frip_est_params = "0.2809;0.8921;7.490e-06;-1.893e-05;-2.178e-05";
 
   // Read with # best mappings greater than it will have this number of best
   // mappings reported.

--- a/src/mapping_parameters.h
+++ b/src/mapping_parameters.h
@@ -29,6 +29,8 @@ struct MappingParameters {
   bool use_all_reads = false;
   bool debug_cache = false;
   std::string frip_est_params = "0.2809;0.8921;7.490e-06;-1.893e-05;-2.178e-05";
+  bool output_num_uniq_cache_slots = true;
+  int k_for_minhash = 250;
 
   // Read with # best mappings greater than it will have this number of best
   // mappings reported.

--- a/src/mapping_writer.h
+++ b/src/mapping_writer.h
@@ -68,7 +68,7 @@ class MappingWriter {
       std::vector<TempMappingFileHandle<MappingRecord>>
           &temp_mapping_file_handles);
 
-  void OutputSummaryMetadata(std::vector<double> frip_est_coeffs = {0.0, 0.0, 0.0, 0.0, 0.0});
+  void OutputSummaryMetadata(std::vector<double> frip_est_coeffs = {0.0, 0.0, 0.0, 0.0, 0.0}, bool output_num_cache_slots_info = true);
   void UpdateSummaryMetadata(uint64_t barcode, int type, int change);
   void UpdateSpeicalCategorySummaryMetadata(int category, int type, int change);
   void AdjustSummaryPairedEndOverCount();
@@ -444,13 +444,14 @@ void MappingWriter<MappingRecord>::OutputMappings(
 }
 
 template <typename MappingRecord>
-void MappingWriter<MappingRecord>::OutputSummaryMetadata(std::vector<double> frip_est_coeffs) {
+void MappingWriter<MappingRecord>::OutputSummaryMetadata(std::vector<double> frip_est_coeffs, bool output_num_cache_slots_info) {
   if (!mapping_parameters_.summary_metadata_file_path.empty())
   {
     summary_metadata_.Output(
         mapping_parameters_.summary_metadata_file_path.c_str(),
         !mapping_parameters_.barcode_whitelist_file_path.empty() && !mapping_parameters_.output_mappings_not_in_whitelist,
-        frip_est_coeffs
+        frip_est_coeffs,
+        output_num_cache_slots_info
         );
   }
 }

--- a/src/mapping_writer.h
+++ b/src/mapping_writer.h
@@ -68,7 +68,7 @@ class MappingWriter {
       std::vector<TempMappingFileHandle<MappingRecord>>
           &temp_mapping_file_handles);
 
-  void OutputSummaryMetadata();
+  void OutputSummaryMetadata(std::vector<double> frip_est_coeffs = {0.0, 0.0, 0.0, 0.0, 0.0});
   void UpdateSummaryMetadata(uint64_t barcode, int type, int change);
   void UpdateSpeicalCategorySummaryMetadata(int category, int type, int change);
   void AdjustSummaryPairedEndOverCount();
@@ -444,11 +444,14 @@ void MappingWriter<MappingRecord>::OutputMappings(
 }
 
 template <typename MappingRecord>
-void MappingWriter<MappingRecord>::OutputSummaryMetadata() {
+void MappingWriter<MappingRecord>::OutputSummaryMetadata(std::vector<double> frip_est_coeffs) {
   if (!mapping_parameters_.summary_metadata_file_path.empty())
   {
-    summary_metadata_.Output(mapping_parameters_.summary_metadata_file_path.c_str(),
-        !mapping_parameters_.barcode_whitelist_file_path.empty() && !mapping_parameters_.output_mappings_not_in_whitelist);
+    summary_metadata_.Output(
+        mapping_parameters_.summary_metadata_file_path.c_str(),
+        !mapping_parameters_.barcode_whitelist_file_path.empty() && !mapping_parameters_.output_mappings_not_in_whitelist,
+        frip_est_coeffs
+        );
   }
 }
 

--- a/src/mmcache.hpp
+++ b/src/mmcache.hpp
@@ -358,11 +358,9 @@ class mm_cache {
   uint32_t GetUpdateThreshold(uint32_t num_loaded_reads, 
                               uint64_t num_reads,
                               bool paired,
-                              bool use_all_reads,
                               double cache_update_param
                               ) {
     const uint32_t block = paired ? 2500000 : 5000000;    
-    if (use_all_reads) {return num_loaded_reads;}
 
     if (num_reads <= block)
       return num_loaded_reads;

--- a/src/summary_metadata.h
+++ b/src/summary_metadata.h
@@ -54,16 +54,16 @@ class SummaryMetadata {
 
     size_t num_lowmapq = counts[SUMMARY_METADATA_LOWMAPQ];
     size_t num_cachehit = counts[SUMMARY_METADATA_CACHEHIT];
-    double fric = (double) num_cachehit / (double) num_mapped;
+    double fric = (num_mapped != 0) ? (double) num_cachehit / (double) num_mapped : 0.0;
 
     size_t num_cache_slots = counts[SUMMARY_METADATA_CARDINALITY];
 
     // compute the estimated frip
-    double est_frip = frip_est_coeffs[0] + /* constant */
+    double est_frip = (fric != 0.0) ? frip_est_coeffs[0] + /* constant */
                       (frip_est_coeffs[1] * fric) +
                       (frip_est_coeffs[2] * num_dup) +
                       (frip_est_coeffs[3] * num_unmapped)  +
-                      (frip_est_coeffs[4] * num_lowmapq);
+                      (frip_est_coeffs[4] * num_lowmapq) : 0.0;
 
     // print out data for current barcode
     if (!output_num_cache_slots_info) {

--- a/src/summary_metadata.h
+++ b/src/summary_metadata.h
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <cmath>
 
 #include "khash.h"
 #include "utils.h"
@@ -43,6 +44,10 @@ class SummaryMetadata {
     kh_destroy(k64_barcode_metadata, barcode_metadata_);
   }
 
+  inline double inverse_logit(double frip) {
+    return (1.0/(1.0 + std::exp(-frip)));
+  }
+
   inline void OutputCounts(const char *barcode, const int *counts, FILE *fp, std::vector<double> frip_est_coeffs, bool output_num_cache_slots_info)
   {
     // define variables to store values
@@ -59,11 +64,11 @@ class SummaryMetadata {
     size_t num_cache_slots = counts[SUMMARY_METADATA_CARDINALITY];
 
     // compute the estimated frip
-    double est_frip = (fric != 0.0) ? frip_est_coeffs[0] + /* constant */
-                      (frip_est_coeffs[1] * fric) +
-                      (frip_est_coeffs[2] * num_dup) +
-                      (frip_est_coeffs[3] * num_unmapped)  +
-                      (frip_est_coeffs[4] * num_lowmapq) : 0.0;
+    double est_frip = (fric != 0.0) ? inverse_logit(frip_est_coeffs[0] + /* constant */
+                                           (frip_est_coeffs[1] * fric) +
+                                           (frip_est_coeffs[2] * num_dup) +
+                                           (frip_est_coeffs[3] * num_unmapped)  +
+                                           (frip_est_coeffs[4] * num_lowmapq)) : 0.0;
 
     // print out data for current barcode
     if (!output_num_cache_slots_info) {


### PR DESCRIPTION
- Adds in options for computing estimated FRIP and cache cardinality at the single-cell level
- Adds in command-line options for controlling cache parameters including parameters for linear regression model